### PR TITLE
Add build artifacts to the continuous integration pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,5 +32,4 @@ jobs:
     name: build
     rust_version: stable
     rust_targets:
-    - x86_64-unknown-linux-gnu
     - x86_64-unknown-linux-musl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,3 +26,11 @@ jobs:
   parameters:
     name: rust_test_stable
     rust_version: stable
+
+- template: ci/azure-pipelines/job-cross-build.yml
+  parameters:
+    name: build
+    rust_version: stable
+    rust_targets:
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-linux-musl

--- a/ci/azure-pipelines/job-cross-build.yml
+++ b/ci/azure-pipelines/job-cross-build.yml
@@ -38,5 +38,5 @@ jobs:
       displayName: Publish artifact ${{ target }}.tar.gz
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
-        artifactName: 'brace-${{ target }}.tar.gz'
+        artifactName: 'brace-${{ target }}'
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/ci/azure-pipelines/job-cross-build.yml
+++ b/ci/azure-pipelines/job-cross-build.yml
@@ -11,7 +11,7 @@ jobs:
   steps:
   - template: step-rust-install.yml
     parameters:
-      rust_version: ${{ parameters.version }}
+      rust_version: ${{ parameters.rust_version }}
 
   - template: step-cross-install.yml
 

--- a/ci/azure-pipelines/job-cross-build.yml
+++ b/ci/azure-pipelines/job-cross-build.yml
@@ -35,5 +35,6 @@ jobs:
 
     - task: PublishBuildArtifacts@1
       displayName: Publish artifact ${{ target }}.tar.gz
-      pathToPublish: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
-      artifactName: 'brace-${{ target }}.tar.gz'
+      inputs:
+        pathToPublish: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
+        artifactName: 'brace-${{ target }}.tar.gz'

--- a/ci/azure-pipelines/job-cross-build.yml
+++ b/ci/azure-pipelines/job-cross-build.yml
@@ -32,9 +32,11 @@ jobs:
         archiveType: 'tar'
         tarCompression: 'gz'
         archiveFile: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
     - task: PublishBuildArtifacts@1
       displayName: Publish artifact ${{ target }}.tar.gz
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
         artifactName: 'brace-${{ target }}.tar.gz'
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/ci/azure-pipelines/job-cross-build.yml
+++ b/ci/azure-pipelines/job-cross-build.yml
@@ -1,0 +1,39 @@
+parameters:
+  rust_version: stable
+  rust_targets:
+  - x86_64-unknown-linux-gnu
+
+jobs:
+- job: ${{ parameters.name }}
+  displayName: Build
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+  - template: step-rust-install.yml
+    parameters:
+      rust_version: ${{ parameters.version }}
+
+  - template: step-cross-install.yml
+
+  - ${{ each target in parameters.rust_targets }}:
+    - script: cross build --all --target ${{ target }} --verbose
+      displayName: Build ${{ target }}
+
+    - script: cross test --all --target ${{ target }} --verbose
+      displayName: Test ${{ target }}
+
+    - script: cross build --release --target ${{ target }} --verbose
+      displayName: Release ${{ target }}
+
+    - task: ArchiveFiles@2
+      displayName: Create artifact ${{ target }}.tar.gz
+      inputs:
+        rootFolderOrFile: '$(Build.SourcesDirectory)/target/${{ target }}/release/brace'
+        archiveType: 'tar'
+        tarCompression: 'gz'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish artifact ${{ target }}.tar.gz
+      pathToPublish: '$(Build.ArtifactStagingDirectory)/brace-${{ target }}.tar.gz'
+      artifactName: 'brace-${{ target }}.tar.gz'

--- a/ci/azure-pipelines/step-cross-install.yml
+++ b/ci/azure-pipelines/step-cross-install.yml
@@ -1,0 +1,12 @@
+steps:
+- script: |
+    set -eou
+    D=$(mktemp -d)
+    git clone https://github.com/rust-embedded/cross.git "$D"
+    git reset --hard 718a19cd68fb09428532d1317515fe7303692b47
+    cd "$D"
+    curl -O -L "https://gist.githubusercontent.com/nickbabcock/c7bdc8e5974ed9956abf46ffd7dc13ff/raw/e211bc17ea88e505003ad763fac7060b4ac1d8d0/patch"
+    git apply patch
+    cargo install --path .
+    rm -rf "$D"
+  displayName: Install cross

--- a/ci/azure-pipelines/step-cross-install.yml
+++ b/ci/azure-pipelines/step-cross-install.yml
@@ -3,8 +3,8 @@ steps:
     set -eou
     D=$(mktemp -d)
     git clone https://github.com/rust-embedded/cross.git "$D"
-    git reset --hard 718a19cd68fb09428532d1317515fe7303692b47
     cd "$D"
+    git reset --hard 718a19cd68fb09428532d1317515fe7303692b47
     curl -O -L "https://gist.githubusercontent.com/nickbabcock/c7bdc8e5974ed9956abf46ffd7dc13ff/raw/e211bc17ea88e505003ad763fac7060b4ac1d8d0/patch"
     git apply patch
     cargo install --path .


### PR DESCRIPTION
The only way to get the project at the moment is to build it from source. This adds build artifacts to the continuous integration pipeline for access to pre-built binaries.