### PR TITLE
Add local tooling to improve development experience

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,62 @@
+[env]
+RUST_BACKTRACE = "1"
+
+[tasks.check]
+command = "cargo"
+args = ["check"]
+
+[tasks.build]
+command = "cargo"
+args = ["build"]
+
+[tasks.test]
+command = "cargo"
+args = ["test"]
+
+[tasks.release]
+command = "cargo"
+args = ["build", "--release"]
+
+[tasks.format]
+command = "cargo"
+args = ["fmt"]
+dependencies = [
+  "install-rustfmt",
+]
+
+[tasks.format-check]
+command = "cargo"
+args = ["fmt", "--", "--check"]
+dependencies = [
+  "install-rustfmt",
+]
+
+[tasks.clippy]
+command = "cargo"
+args = ["clippy", "--", "-D", "warnings"]
+dependencies = [
+  "install-clippy",
+]
+
+[tasks.lint]
+dependencies = [
+  "format-check",
+  "clippy",
+]
+
+[tasks.git-pre-commit]
+dependencies = [
+  "check",
+  "lint",
+]
+
+[tasks.git-pre-push]
+dependencies = [
+  "test",
+]
+
+[tasks.install-rustfmt]
+install_crate = { crate_name = "rustfmt", rustup_component_name = "rustfmt", binary = "cargo-fmt", test_arg = "--help" }
+
+[tasks.install-clippy]
+install_crate = { crate_name = "clippy", rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }

--- a/ci/azure-pipelines/job-rust-lint.yml
+++ b/ci/azure-pipelines/job-rust-lint.yml
@@ -11,5 +11,11 @@ jobs:
   - script: rustup component add rustfmt
     displayName: Install rustfmt
 
+  - script: rustup component add clippy
+    displayName: Install clippy
+
   - script: cargo fmt --all -- --check
     displayName: Run rustfmt
+
+  - script: cargo clippy -- -D warnings
+    displayName: Run clippy

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 16

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,13 @@
+edition = "2018"
+force_explicit_abi = true
+hard_tabs = false
+max_width = 100
+merge_derives = true
+newline_style = "Auto"
+remove_nested_parens = true
+reorder_imports = true
+reorder_modules = true
+tab_spaces = 4
+use_field_init_shorthand = false
+use_small_heuristics = "Default"
+use_try_shorthand = false

--- a/rusty-hook.toml
+++ b/rusty-hook.toml
@@ -1,0 +1,6 @@
+[hooks]
+pre-commit = "cargo fmt -- --check"
+pre-push = "cargo test"
+
+[logging]
+verbose = false

--- a/rusty-hook.toml
+++ b/rusty-hook.toml
@@ -1,6 +1,6 @@
 [hooks]
-pre-commit = "cargo fmt -- --check"
-pre-push = "cargo test"
+pre-commit = "cargo make git-pre-commit"
+pre-push = "cargo make git-pre-push"
 
 [logging]
 verbose = false

--- a/src/lib/util/shell.rs
+++ b/src/lib/util/shell.rs
@@ -9,6 +9,12 @@ pub struct Shell {
     verbosity: Verbosity,
 }
 
+impl Default for Shell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Shell {
     pub fn new() -> Self {
         Self {
@@ -141,10 +147,13 @@ impl Into<TermColorChoice> for ColorChoice {
         match self {
             ColorChoice::Never => TermColorChoice::Never,
             ColorChoice::Always => TermColorChoice::Always,
-            ColorChoice::Auto => match atty::is(atty::Stream::Stderr) {
-                true => TermColorChoice::Auto,
-                false => TermColorChoice::Never,
-            },
+            ColorChoice::Auto => {
+                if atty::is(atty::Stream::Stderr) {
+                    TermColorChoice::Auto
+                } else {
+                    TermColorChoice::Never
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The current development experience for this project means that mistakes and bugs can easily slip through the cracks to only be discovered once the build pipeline fails. This leads to clutter in the branch commit history and wasted time.

This adds local tooling to reduce the likelihood of a pipeline job failing by ensuring that lints and tests are run before code is committed and pushed. This is achieved through several tools:

- _cargo-make_ - A tool for defining common tasks and flows. No more remembering which commands to run in which order and with which arguments.
- _rusty-hook_ - Simplifies git hook integration into a single file. The tool still needs some work as the hooks are not yet automatically made executable. A git GUI may not make this apparent.
- _rustfmt_ - The configuration is now specified in the repository rather than relying on the defaults.
- _clippy_ - Lints code to ensure it follows coding standards.
