### PR TITLE
Add support for multiple log backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,8 +479,9 @@ dependencies = [
  "brace-cli 0.1.0",
  "brace-db 0.1.0",
  "brace-theme 0.1.0",
- "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-absolutize 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,18 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +833,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fallible-iterator"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fern"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "flate2"
@@ -1004,14 +1001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "humansize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "humantime"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "hyper"
@@ -2721,13 +2710,13 @@ dependencies = [
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum enum-as-inner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d58266c97445680766be408285e798d3401c6d4c378ec5552e78737e681e37d"
-"checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb9adbf9874d5d028b5e4c5739d22b71988252b25c9c98fe7cf9738bee84597"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -2748,7 +2737,6 @@ dependencies = [
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
-"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5b6658b016965ae301fa995306db965c93677880ea70765a84235a96eae896"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"

--- a/crates/brace-web/Cargo.toml
+++ b/crates/brace-web/Cargo.toml
@@ -20,8 +20,9 @@ actix-web = "1.0.0-alpha.2"
 brace-cli = { path = "../brace-cli" }
 brace-db = { path = "../brace-db" }
 brace-theme = { path = "../brace-theme" }
-env_logger = "0.6"
+chrono = "0.4"
 failure = "0.1"
+fern = "0.5"
 futures = "0.1"
 log = "0.4"
 path-absolutize = "1.1"

--- a/crates/brace-web/src/lib/cli/run.rs
+++ b/crates/brace-web/src/lib/cli/run.rs
@@ -1,3 +1,4 @@
+use std::env::current_dir;
 use std::net::Ipv4Addr;
 use std::path::Path;
 
@@ -40,7 +41,7 @@ pub fn exec(shell: &mut Shell, matches: &ArgMatches) -> ExecResult {
                 let config = overload_file(file, config, shell, matches)?;
 
                 shell.info(format!("Using configuration file: {}", file))?;
-                crate::run(config)?;
+                crate::run(config, Path::new(file))?;
 
                 Ok(())
             }
@@ -53,7 +54,7 @@ pub fn exec(shell: &mut Shell, matches: &ArgMatches) -> ExecResult {
             let config = overload_default(shell, matches)?;
 
             shell.warn("No configuration file specified")?;
-            crate::run(config)?;
+            crate::run(config, &current_dir()?)?;
 
             Ok(())
         }

--- a/crates/brace-web/src/lib/config.rs
+++ b/crates/brace-web/src/lib/config.rs
@@ -1,12 +1,12 @@
 use std::fmt::{Display, Formatter, Result as FormatResult};
 use std::net::Ipv4Addr;
+use std::path::{Path, PathBuf};
 
 use brace_db::DatabaseConfig;
 use brace_theme::config::ThemeReferenceInfo;
+use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
-use std::path::{Path, PathBuf};
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
@@ -68,6 +68,8 @@ impl Default for WebConfig {
 pub struct WebLogConfig {
     pub level: LogLevel,
     pub format: String,
+    pub output: LogOutput,
+    pub file: Option<PathBuf>,
 }
 
 impl Default for WebLogConfig {
@@ -75,6 +77,8 @@ impl Default for WebLogConfig {
         Self {
             level: LogLevel::Warn,
             format: r#"%a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#.to_string(),
+            output: LogOutput::Stderr,
+            file: None,
         }
     }
 }
@@ -99,6 +103,37 @@ impl Display for LogLevel {
             LogLevel::Info => write!(f, "info"),
             LogLevel::Debug => write!(f, "debug"),
             LogLevel::Trace => write!(f, "trace"),
+        }
+    }
+}
+
+impl Into<LevelFilter> for LogLevel {
+    fn into(self) -> LevelFilter {
+        match self {
+            LogLevel::Off => LevelFilter::Off,
+            LogLevel::Error => LevelFilter::Error,
+            LogLevel::Warn => LevelFilter::Warn,
+            LogLevel::Info => LevelFilter::Info,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum LogOutput {
+    Stdout,
+    Stderr,
+    File,
+}
+
+impl Display for LogOutput {
+    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+        match self {
+            LogOutput::Stdout => write!(f, "stdout"),
+            LogOutput::Stderr => write!(f, "stderr"),
+            LogOutput::File => write!(f, "file"),
         }
     }
 }

--- a/crates/brace-web/src/lib/lib.rs
+++ b/crates/brace-web/src/lib/lib.rs
@@ -16,6 +16,7 @@ use crate::util::path::get_dir;
 
 pub mod cli;
 pub mod config;
+pub mod logger;
 pub mod route;
 pub mod state;
 pub mod util;
@@ -30,15 +31,8 @@ pub fn init(config: AppConfig, path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn run(config: AppConfig) -> Result<(), Error> {
-    std::env::set_var(
-        "RUST_LOG",
-        format!(
-            "actix_web={},brace={}",
-            config.web.log.level, config.web.log.level
-        ),
-    );
-    env_logger::init();
+pub fn run(config: AppConfig, path: &Path) -> Result<(), Error> {
+    logger::init(&config, path)?;
 
     let system = System::new("brace");
     let state = AppState::from_config(config.clone())?;

--- a/crates/brace-web/src/lib/logger.rs
+++ b/crates/brace-web/src/lib/logger.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+
+use chrono::Local;
+use failure::Error;
+use fern::{log_file, Dispatch};
+use log::{warn, LevelFilter};
+use path_absolutize::Absolutize;
+
+use crate::config::{AppConfig, LogOutput};
+
+pub fn init(conf: &AppConfig, path: &Path) -> Result<(), Error> {
+    let logger = Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{} {} {}] {}",
+                Local::now().format("%Y-%m-%dT%H:%M:%SZ"),
+                record.level(),
+                record.target(),
+                message
+            ))
+        })
+        .level(LevelFilter::Off)
+        .level_for("brace", conf.web.log.level.clone().into())
+        .level_for("brace_web", conf.web.log.level.clone().into())
+        .level_for("actix_web", conf.web.log.level.clone().into());
+
+    match conf.web.log.output {
+        LogOutput::Stdout => logger.chain(std::io::stdout()).apply()?,
+        LogOutput::Stderr => logger.chain(std::io::stderr()).apply()?,
+        LogOutput::File => match &conf.web.log.file {
+            Some(file) => {
+                let path = path.join("..").join(file).absolutize()?;
+                logger.chain(log_file(path)?).apply()?;
+            }
+            None => {
+                logger.chain(std::io::stderr()).apply()?;
+                warn!("Invalid log file specified: {:?}", &conf.web.log.file);
+            }
+        },
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Addresses issue #16. Initial implementation adds support for stdout, stderr and file logging. Additional support should be added in a follow-up pull request.