### PR TITLE
Add a configuration management system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "actix-web 1.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brace-cli 0.1.0",
+ "brace-config 0.1.0",
  "brace-db 0.1.0",
  "brace-theme 0.1.0",
  "brace-web 0.1.0",
@@ -481,6 +482,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "brace-config"
+version = "0.1.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "brace-db"
 version = "0.1.0"
 dependencies = [
@@ -500,6 +512,7 @@ dependencies = [
  "actix 0.8.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brace-cli 0.1.0",
+ "brace-config 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-absolutize 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2020,6 +2033,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2753,14 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yaml-rust"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f"
 "checksum actix 0.8.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d06155c5af1cd45f2a3b89bf16f76b7c7f5ef0148ff642dbbbbadf1d3d1dc550"
@@ -2934,6 +2966,7 @@ dependencies = [
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2"
+"checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
@@ -3016,3 +3049,4 @@ dependencies = [
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/brace",
   "crates/brace-cli",
+  "crates/brace-config",
   "crates/brace-db",
   "crates/brace-theme",
   "crates/brace-web",

--- a/ci/azure-pipelines/job-rust-test.yml
+++ b/ci/azure-pipelines/job-rust-test.yml
@@ -10,5 +10,5 @@ jobs:
     parameters:
       rust_version: ${{ parameters.rust_version }}
 
-  - script: cargo test --all
+  - script: cargo test --all -- --test-threads=1
     displayName: Run cargo test

--- a/crates/brace-config/Cargo.toml
+++ b/crates/brace-config/Cargo.toml
@@ -18,3 +18,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 toml = "0.5"
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/brace-config/Cargo.toml
+++ b/crates/brace-config/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "brace-config"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "The config component of the brace project."
+edition = "2018"
+homepage = "https://github.com/brace-rs/brace"
+repository = "https://github.com/brace-rs/brace"
+license = "MIT OR Apache-2.0"
+
+[lib]
+name = "brace_config"
+path = "src/lib/lib.rs"
+
+[dependencies]
+failure = "0.1"
+serde = "1.0"
+serde_json = "1.0"
+serde_yaml = "0.8"
+toml = "0.5"

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::file::load_from_file;
+use super::{load, save};
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -82,9 +82,18 @@ impl Config {
     where
         P: AsRef<Path>,
     {
-        let conf: HashMap<String, Value> = load_from_file(path)?;
+        let conf: HashMap<String, Value> = load::file(path)?;
 
         Ok(Self { config: conf })
+    }
+
+    pub fn save<P>(&self, path: P) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+    {
+        save::file(path, &self.config)?;
+
+        Ok(())
     }
 
     pub fn lock(self) -> ImmutableConfig {

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use failure::{format_err, Error};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use super::file::load_from_file;
 
@@ -22,13 +22,32 @@ impl Config {
     where
         T: Serialize,
     {
-        let value = serde_json::to_value(value)?;
-
         if key.is_empty() {
             return Err(format_err!("Invalid key"));
         }
 
-        self.config.insert(key.into(), value);
+        let keys: Vec<&str> = key.splitn(2, '.').collect();
+
+        if keys.len() == 1 {
+            self.config.insert(key.into(), serde_json::to_value(value)?);
+        } else {
+            match self.config.get_mut(keys[0]) {
+                Some(target) => match set(target, keys[1], serde_json::to_value(value)?) {
+                    Ok(_) => (),
+                    Err(err) => return Err(err),
+                },
+                None => {
+                    let mut obj = Value::Object(Map::new());
+
+                    match set(&mut obj, keys[1], serde_json::to_value(value)?) {
+                        Ok(_) => {
+                            self.config.insert(keys[0].into(), obj);
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            }
+        }
 
         Ok(self)
     }
@@ -41,9 +60,21 @@ impl Config {
             return Err(format_err!("Invalid key"));
         }
 
-        match self.config.get(key) {
-            Some(value) => Ok(T::deserialize(value)?),
-            None => Err(format_err!("Could not find key {}", key)),
+        let keys: Vec<&str> = key.splitn(2, '.').collect();
+
+        if keys.len() == 1 {
+            match self.config.get(key) {
+                Some(value) => Ok(T::deserialize(value)?),
+                None => Err(format_err!("Invalid key {}", key)),
+            }
+        } else {
+            match self.config.get(keys[0]) {
+                Some(value) => match get(value, keys[1]) {
+                    Some(value) => Ok(T::deserialize(value)?),
+                    None => Err(format_err!("Invalid key {}", key)),
+                },
+                None => Err(format_err!("Invalid key {}", key)),
+            }
         }
     }
 
@@ -97,6 +128,97 @@ impl ImmutableConfig {
     }
 }
 
+fn get<'a>(source: &'a Value, key: &str) -> Option<&'a Value> {
+    let keys = key.split('.');
+    let mut target = source;
+
+    for key in keys {
+        let target_opt = match *target {
+            Value::Object(ref map) => map.get(key),
+            Value::Array(ref arr) => key.parse::<usize>().ok().and_then(|x| arr.get(x)),
+            _ => return None,
+        };
+        if let Some(t) = target_opt {
+            target = t;
+        } else {
+            return None;
+        }
+    }
+
+    Some(target)
+}
+
+fn set<'a>(source: &'a mut Value, key: &str, value: Value) -> Result<(), Error> {
+    let keys: Vec<&str> = key.splitn(2, '.').collect();
+    let key = keys[0];
+
+    if keys.len() == 1 {
+        match source {
+            Value::Object(map) => {
+                map.insert(key.into(), value);
+            }
+            Value::Array(arr) => {
+                arr.insert(key.parse()?, value);
+            }
+            Value::Null => match key.parse::<usize>() {
+                Ok(key) => {
+                    let mut arr = Vec::new();
+                    arr.insert(key, value);
+                    *source = Value::Array(arr);
+                }
+                Err(_) => {
+                    let mut map = Map::new();
+                    map.insert(key.into(), value);
+                    *source = Value::Object(map);
+                }
+            },
+            _ => return Err(format_err!("Unsupported nesting")),
+        }
+    } else {
+        let tail = keys[1];
+
+        match source {
+            Value::Object(map) => match map.get_mut(key) {
+                Some(target) => return set(target, tail, value),
+                None => {
+                    let mut obj = Value::Object(Map::new());
+                    match set(&mut obj, tail, value) {
+                        Ok(_) => {
+                            map.insert(key.into(), obj);
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            },
+            Value::Array(arr) => match arr.get_mut(key.parse::<usize>()?) {
+                Some(target) => return set(target, tail, value),
+                None => {
+                    let mut obj = Value::Object(Map::new());
+                    match set(&mut obj, tail, value) {
+                        Ok(_) => {
+                            arr.insert(key.parse()?, obj);
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            },
+            Value::Null => match key.parse::<usize>() {
+                Ok(_) => {
+                    *source = Value::Array(Vec::new());
+                    return set(source, key, value);
+                }
+                Err(_) => {
+                    *source = Value::Object(Map::new());
+                    return set(source, key, value);
+                }
+            },
+            _ => return Err(format_err!("Unsupported nesting")),
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
@@ -104,7 +226,7 @@ mod tests {
     use super::Config;
 
     #[test]
-    fn test_config_getters() {
+    fn test_config() {
         let mut conf = Config::new();
 
         conf.set("host", "127.0.0.1").unwrap();
@@ -122,6 +244,36 @@ mod tests {
             conf.get::<Ipv4Addr>("host").unwrap(),
             Ipv4Addr::new(127, 0, 0, 1)
         );
+    }
+
+    #[test]
+    fn test_config_nested() {
+        let mut conf = Config::new();
+
+        conf.set("web.host", "127.0.0.1").unwrap();
+
+        assert_eq!(
+            conf.get::<String>("web.host").unwrap(),
+            "127.0.0.1".to_string()
+        );
+        assert_eq!(
+            conf.get::<Ipv4Addr>("web.host").unwrap(),
+            Ipv4Addr::new(127, 0, 0, 1)
+        );
+
+        conf.set("web.host", Ipv4Addr::new(127, 0, 0, 1)).unwrap();
+
+        assert_eq!(
+            conf.get::<String>("web.host").unwrap(),
+            "127.0.0.1".to_string()
+        );
+        assert_eq!(
+            conf.get::<Ipv4Addr>("web.host").unwrap(),
+            Ipv4Addr::new(127, 0, 0, 1)
+        );
+
+        assert!(conf.set("web.address.host", "127.0.0.1").is_ok());
+        assert!(conf.set("web.host.address", "127.0.0.1").is_err());
     }
 
     #[test]

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -18,7 +18,7 @@ impl Config {
         Self::default()
     }
 
-    pub fn set<T>(&mut self, key: &str, value: T) -> Result<(), Error>
+    pub fn set<T>(&mut self, key: &str, value: T) -> Result<&mut Config, Error>
     where
         T: Serialize,
     {
@@ -26,7 +26,7 @@ impl Config {
 
         self.config.insert(key.into(), value);
 
-        Ok(())
+        Ok(self)
     }
 
     pub fn get<T>(&self, key: &str) -> Result<T, Error>
@@ -82,5 +82,18 @@ mod tests {
             conf.get::<Ipv4Addr>("host").unwrap(),
             Ipv4Addr::new(127, 0, 0, 1)
         );
+    }
+
+    #[test]
+    fn test_config_chaining() {
+        let mut conf = Config::new();
+
+        conf.set("host", "127.0.0.1")
+            .unwrap()
+            .set("port", 80)
+            .unwrap();
+
+        assert_eq!(conf.get::<String>("host").unwrap(), "127.0.0.1".to_string());
+        assert_eq!(conf.get::<i32>("port").unwrap(), 80);
     }
 }

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -33,7 +33,7 @@ impl Config {
     where
         T: DeserializeOwned,
     {
-        match self.config.get(key.into()) {
+        match self.config.get(key) {
             Some(value) => Ok(T::deserialize(value)?),
             None => Err(format_err!("Could not find key {}", key)),
         }

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -24,6 +24,10 @@ impl Config {
     {
         let value = serde_json::to_value(value)?;
 
+        if key.is_empty() {
+            return Err(format_err!("Invalid key"));
+        }
+
         self.config.insert(key.into(), value);
 
         Ok(self)
@@ -33,6 +37,10 @@ impl Config {
     where
         T: DeserializeOwned,
     {
+        if key.is_empty() {
+            return Err(format_err!("Invalid key"));
+        }
+
         match self.config.get(key) {
             Some(value) => Ok(T::deserialize(value)?),
             None => Err(format_err!("Could not find key {}", key)),

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use failure::Error;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::file::load_from_file;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    config: HashMap<String, Value>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set<T>(&mut self, key: &str, value: T)
+    where
+        T: Serialize,
+    {
+        self.config
+            .insert(key.into(), serde_json::to_value(value).unwrap());
+    }
+
+    pub fn get<T>(&self, key: &str) -> Option<T>
+    where
+        T: DeserializeOwned,
+    {
+        match self.config.get(key.into()) {
+            Some(value) => match T::deserialize(value) {
+                Ok(value) => Some(value),
+                Err(_) => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn load<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let conf: HashMap<String, Value> = load_from_file(path)?;
+
+        Ok(Self { config: conf })
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            config: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::Config;
+
+    #[test]
+    fn test_config_getters() {
+        let mut conf = Config::new();
+
+        conf.set("host", "127.0.0.1");
+
+        assert_eq!(conf.get::<String>("host"), Some("127.0.0.1".to_string()));
+        assert_eq!(
+            conf.get::<Ipv4Addr>("host"),
+            Some(Ipv4Addr::new(127, 0, 0, 1))
+        );
+
+        conf.set("host", Ipv4Addr::new(127, 0, 0, 1));
+
+        assert_eq!(conf.get::<String>("host"), Some("127.0.0.1".to_string()));
+        assert_eq!(
+            conf.get::<Ipv4Addr>("host"),
+            Some(Ipv4Addr::new(127, 0, 0, 1))
+        );
+    }
+}

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -47,6 +47,10 @@ impl Config {
 
         Ok(Self { config: conf })
     }
+
+    pub fn lock(self) -> ImmutableConfig {
+        ImmutableConfig { config: self }
+    }
 }
 
 impl Default for Config {
@@ -54,6 +58,28 @@ impl Default for Config {
         Self {
             config: HashMap::new(),
         }
+    }
+}
+
+pub struct ImmutableConfig {
+    config: Config,
+}
+
+impl ImmutableConfig {
+    pub fn get<T>(&self, key: &str) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        self.config.get(key)
+    }
+
+    pub fn load<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let conf = Config::load(path)?;
+
+        Ok(Self { config: conf })
     }
 }
 
@@ -95,5 +121,16 @@ mod tests {
 
         assert_eq!(conf.get::<String>("host").unwrap(), "127.0.0.1".to_string());
         assert_eq!(conf.get::<i32>("port").unwrap(), 80);
+    }
+
+    #[test]
+    fn test_immutable_config() {
+        let mut conf = Config::new();
+
+        conf.set("host", "127.0.0.1").unwrap();
+
+        let conf = conf.lock();
+
+        assert_eq!(conf.get::<String>("host").unwrap(), "127.0.0.1".to_string());
     }
 }

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -51,6 +51,12 @@ impl Config {
     pub fn lock(self) -> ImmutableConfig {
         ImmutableConfig { config: self }
     }
+
+    pub fn merge(&mut self, config: &Config) -> &mut Config {
+        self.config
+            .extend(config.config.iter().map(|(k, v)| (k.clone(), v.clone())));
+        self
+    }
 }
 
 impl Default for Config {
@@ -132,5 +138,21 @@ mod tests {
         let conf = conf.lock();
 
         assert_eq!(conf.get::<String>("host").unwrap(), "127.0.0.1".to_string());
+    }
+
+    #[test]
+    fn test_config_merging() {
+        let mut conf1 = Config::new();
+        let mut conf2 = Config::new();
+
+        conf1.set("host", "127.0.0.1").unwrap();
+        conf2.set("port", 80).unwrap();
+        conf1.merge(&conf2);
+
+        assert_eq!(
+            conf1.get::<String>("host").unwrap(),
+            "127.0.0.1".to_string()
+        );
+        assert_eq!(conf1.get::<i32>("port").unwrap(), 80);
     }
 }

--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -29,6 +29,15 @@ impl Config {
         Ok(self)
     }
 
+    pub fn set_default<T>(&mut self, key: &str, value: T) -> Result<&mut Config, Error>
+    where
+        T: Serialize,
+    {
+        self.0.set_default(key, value)?;
+
+        Ok(self)
+    }
+
     pub fn load<P>(path: P) -> Result<Self, Error>
     where
         P: AsRef<Path>,
@@ -55,6 +64,12 @@ impl Config {
 
     pub fn merge(&mut self, config: &Config) -> Result<&mut Config, Error> {
         self.0.merge(&config.0)?;
+
+        Ok(self)
+    }
+
+    pub fn merge_default(&mut self, config: &Config) -> Result<&mut Config, Error> {
+        self.0.merge_default(&config.0)?;
 
         Ok(self)
     }

--- a/crates/brace-config/src/lib/file.rs
+++ b/crates/brace-config/src/lib/file.rs
@@ -1,0 +1,61 @@
+use std::fs::read_to_string;
+use std::path::Path;
+
+use failure::{format_err, Error};
+use serde::de::DeserializeOwned;
+
+pub fn load_from_file<T, P>(path: P) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+    P: AsRef<Path>,
+{
+    match path.as_ref().extension() {
+        Some(ext) => match ext.to_str() {
+            Some("toml") => load_from_toml(path),
+            Some("yml") => load_from_yaml(path),
+            Some("yaml") => load_from_yaml(path),
+            Some("json") => load_from_json(path),
+            _ => Err(format_err!(
+                "The given path '{:?}' is not a recognized configuration format",
+                path.as_ref()
+            )),
+        },
+        None => Err(format_err!(
+            "The given path '{:?}' is not a recognized configuration format",
+            path.as_ref()
+        )),
+    }
+}
+
+pub fn load_from_toml<T, P>(path: P) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+    P: AsRef<Path>,
+{
+    let string = read_to_string(path)?;
+    let config = toml::from_str::<T>(&string)?;
+
+    Ok(config)
+}
+
+pub fn load_from_yaml<T, P>(path: P) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+    P: AsRef<Path>,
+{
+    let string = read_to_string(path)?;
+    let config = serde_yaml::from_str::<T>(&string)?;
+
+    Ok(config)
+}
+
+pub fn load_from_json<T, P>(path: P) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+    P: AsRef<Path>,
+{
+    let string = read_to_string(path)?;
+    let config = serde_json::from_str::<T>(&string)?;
+
+    Ok(config)
+}

--- a/crates/brace-config/src/lib/lib.rs
+++ b/crates/brace-config/src/lib/lib.rs
@@ -1,0 +1,1 @@
+pub mod file;

--- a/crates/brace-config/src/lib/lib.rs
+++ b/crates/brace-config/src/lib/lib.rs
@@ -2,7 +2,7 @@ pub use self::config::Config;
 pub use self::value::array::Array;
 pub use self::value::entry::Entry;
 pub use self::value::table::Table;
-pub use self::value::Value;
+pub use self::value::{from_value, to_value, Value};
 
 pub mod config;
 pub mod load;

--- a/crates/brace-config/src/lib/lib.rs
+++ b/crates/brace-config/src/lib/lib.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod file;

--- a/crates/brace-config/src/lib/lib.rs
+++ b/crates/brace-config/src/lib/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
-pub mod file;
+pub mod load;
+pub mod save;

--- a/crates/brace-config/src/lib/lib.rs
+++ b/crates/brace-config/src/lib/lib.rs
@@ -1,3 +1,10 @@
+pub use self::config::Config;
+pub use self::value::array::Array;
+pub use self::value::entry::Entry;
+pub use self::value::table::Table;
+pub use self::value::Value;
+
 pub mod config;
 pub mod load;
 pub mod save;
+pub mod value;

--- a/crates/brace-config/src/lib/load.rs
+++ b/crates/brace-config/src/lib/load.rs
@@ -4,17 +4,17 @@ use std::path::Path;
 use failure::{format_err, Error};
 use serde::de::DeserializeOwned;
 
-pub fn load_from_file<T, P>(path: P) -> Result<T, Error>
+pub fn file<T, P>(path: P) -> Result<T, Error>
 where
     T: DeserializeOwned,
     P: AsRef<Path>,
 {
     match path.as_ref().extension() {
         Some(ext) => match ext.to_str() {
-            Some("toml") => load_from_toml(path),
-            Some("yml") => load_from_yaml(path),
-            Some("yaml") => load_from_yaml(path),
-            Some("json") => load_from_json(path),
+            Some("toml") => toml(path),
+            Some("yml") => yaml(path),
+            Some("yaml") => yaml(path),
+            Some("json") => json(path),
             _ => Err(format_err!(
                 "The given path '{:?}' is not a recognized configuration format",
                 path.as_ref()
@@ -27,7 +27,7 @@ where
     }
 }
 
-pub fn load_from_toml<T, P>(path: P) -> Result<T, Error>
+pub fn toml<T, P>(path: P) -> Result<T, Error>
 where
     T: DeserializeOwned,
     P: AsRef<Path>,
@@ -38,7 +38,7 @@ where
     Ok(config)
 }
 
-pub fn load_from_yaml<T, P>(path: P) -> Result<T, Error>
+pub fn yaml<T, P>(path: P) -> Result<T, Error>
 where
     T: DeserializeOwned,
     P: AsRef<Path>,
@@ -49,7 +49,7 @@ where
     Ok(config)
 }
 
-pub fn load_from_json<T, P>(path: P) -> Result<T, Error>
+pub fn json<T, P>(path: P) -> Result<T, Error>
 where
     T: DeserializeOwned,
     P: AsRef<Path>,

--- a/crates/brace-config/src/lib/save.rs
+++ b/crates/brace-config/src/lib/save.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use failure::{format_err, Error};
 use serde::Serialize;
+use toml::Value;
 
 pub fn file<T, P>(path: P, value: &T) -> Result<(), Error>
 where
@@ -33,6 +34,7 @@ where
     T: Serialize,
     P: AsRef<Path>,
 {
+    let value = Value::try_from(value)?;
     let string = toml::to_string_pretty(&value)?;
     let mut file = OpenOptions::new()
         .write(true)

--- a/crates/brace-config/src/lib/save.rs
+++ b/crates/brace-config/src/lib/save.rs
@@ -1,0 +1,80 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use failure::{format_err, Error};
+use serde::Serialize;
+
+pub fn file<T, P>(path: P, value: &T) -> Result<(), Error>
+where
+    T: Serialize,
+    P: AsRef<Path>,
+{
+    match path.as_ref().extension() {
+        Some(ext) => match ext.to_str() {
+            Some("toml") => toml(path, value),
+            Some("yml") => yaml(path, value),
+            Some("yaml") => yaml(path, value),
+            Some("json") => json(path, value),
+            _ => Err(format_err!(
+                "The given path '{:?}' is not a recognized configuration format",
+                path.as_ref()
+            )),
+        },
+        None => Err(format_err!(
+            "The given path '{:?}' is not a recognized configuration format",
+            path.as_ref()
+        )),
+    }
+}
+
+pub fn toml<T, P>(path: P, value: &T) -> Result<(), Error>
+where
+    T: Serialize,
+    P: AsRef<Path>,
+{
+    let string = toml::to_string_pretty(&value)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+
+    file.write_all(string.as_ref())?;
+
+    Ok(())
+}
+
+pub fn yaml<T, P>(path: P, value: &T) -> Result<(), Error>
+where
+    T: Serialize,
+    P: AsRef<Path>,
+{
+    let string = serde_yaml::to_string(&value)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+
+    file.write_all(string.as_ref())?;
+
+    Ok(())
+}
+
+pub fn json<T, P>(path: P, value: &T) -> Result<(), Error>
+where
+    T: Serialize,
+    P: AsRef<Path>,
+{
+    let string = serde_json::to_string_pretty(&value)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+
+    file.write_all(string.as_ref())?;
+
+    Ok(())
+}

--- a/crates/brace-config/src/lib/value/array.rs
+++ b/crates/brace-config/src/lib/value/array.rs
@@ -1,0 +1,305 @@
+use std::fmt::{self, Debug};
+use std::slice::{Iter, IterMut};
+use std::vec::IntoIter;
+
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+use serde::ser::{Serialize, Serializer};
+
+use super::{ser::ValueSerializer, Error, Value};
+
+#[derive(Clone, PartialEq)]
+pub struct Array(pub(crate) Vec<Value>);
+
+impl Array {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn get<'de, T>(&'de self, key: &str) -> Result<T, Error>
+    where
+        T: 'de + Deserialize<'de>,
+    {
+        let keys: Vec<&str> = key.splitn(2, '.').collect();
+
+        if keys.is_empty() {
+            Err(Error::custom("empty key"))
+        } else {
+            match keys[0].parse::<usize>() {
+                Ok(key) => {
+                    if keys.len() == 1 {
+                        match self.0.get(key) {
+                            Some(value) => value.val(),
+                            None => Err(Error::custom(format!("missing value for '{}'", key))),
+                        }
+                    } else {
+                        match self.0.get(key) {
+                            Some(value) => value.get(keys[1]),
+                            None => Err(Error::custom(format!("missing value for '{}'", key))),
+                        }
+                    }
+                }
+                Err(err) => Err(Error::custom(err)),
+            }
+        }
+    }
+
+    pub fn get_value(&self, key: &str) -> Result<&Value, Error> {
+        let keys: Vec<&str> = key.splitn(2, '.').collect();
+
+        if keys.is_empty() {
+            Err(Error::custom("empty key"))
+        } else {
+            match keys[0].parse::<usize>() {
+                Ok(key) => {
+                    if keys.len() == 1 {
+                        match self.0.get(key) {
+                            Some(value) => Ok(value),
+                            None => Err(Error::custom(format!("missing value for '{}'", key))),
+                        }
+                    } else {
+                        match self.0.get(key) {
+                            Some(value) => value.get_value(keys[1]),
+                            None => Err(Error::custom(format!("missing value for '{}'", key))),
+                        }
+                    }
+                }
+                Err(err) => Err(Error::custom(err)),
+            }
+        }
+    }
+
+    pub fn set<T>(&mut self, key: &str, value: T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        let keys: Vec<&str> = key.splitn(3, '.').collect();
+
+        if keys.is_empty() {
+            Err(Error::custom("empty key"))
+        } else {
+            match keys[0].parse::<usize>() {
+                Ok(key) => {
+                    if key > self.0.len() {
+                        Err(Error::custom("cannot insert item after index"))
+                    } else if keys.len() == 1 {
+                        self.0.insert(
+                            key,
+                            value.serialize(ValueSerializer).map_err(Error::custom)?,
+                        );
+
+                        Ok(())
+                    } else {
+                        let peek = keys[1].to_string();
+                        let mut tail = keys[1].to_string();
+
+                        if keys.len() == 3 {
+                            tail.push('.');
+                            tail.push_str(keys[2]);
+                        }
+
+                        match self.0.get_mut(key) {
+                            Some(val) => match val {
+                                Value::Entry(_) => Err(Error::custom("cannot insert into entry")),
+                                Value::Array(array) => array.set(&tail, value),
+                                Value::Table(table) => table.set(&tail, value),
+                            },
+                            None => {
+                                match peek.parse::<usize>() {
+                                    Ok(_) => {
+                                        let mut array = Value::array();
+
+                                        array.set(&tail, value)?;
+                                        self.0.insert(key, array);
+                                    }
+                                    Err(_) => {
+                                        let mut table = Value::table();
+
+                                        table.set(&tail, value)?;
+                                        self.0.insert(key, table);
+                                    }
+                                }
+
+                                Ok(())
+                            }
+                        }
+                    }
+                }
+                Err(err) => Err(Error::custom(err)),
+            }
+        }
+    }
+
+    pub fn set_value(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        let keys: Vec<&str> = key.splitn(3, '.').collect();
+
+        if keys.is_empty() {
+            Err(Error::custom("empty key"))
+        } else {
+            match keys[0].parse::<usize>() {
+                Ok(key) => {
+                    if key > self.0.len() {
+                        Err(Error::custom("cannot insert item after index"))
+                    } else if keys.len() == 1 {
+                        self.0.insert(key, value);
+
+                        Ok(())
+                    } else {
+                        let peek = keys[1].to_string();
+                        let mut tail = keys[1].to_string();
+
+                        if keys.len() == 3 {
+                            tail.push_str(keys[2]);
+                        }
+
+                        match self.0.get_mut(key) {
+                            Some(val) => val.set_value(keys[1], value),
+                            None => {
+                                match peek.parse::<usize>() {
+                                    Ok(_) => {
+                                        let mut array = Value::array();
+
+                                        array.set_value(&tail, value)?;
+                                        self.0.insert(key, array);
+                                    }
+                                    Err(_) => {
+                                        let mut table = Value::table();
+
+                                        table.set_value(&tail, value)?;
+                                        self.0.insert(key, table);
+                                    }
+                                }
+
+                                Ok(())
+                            }
+                        }
+                    }
+                }
+                Err(err) => Err(Error::custom(err)),
+            }
+        }
+    }
+
+    pub fn merge(&mut self, array: &Self) -> Result<(), Error> {
+        for (idx, val) in array.0.iter().enumerate() {
+            match self.0.get_mut(idx) {
+                Some(item) => {
+                    item.merge(&val)?;
+                }
+                None => {
+                    self.0.push(val.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn merge_value(&mut self, value: &Value) -> Result<(), Error> {
+        match value {
+            Value::Entry(_) => Err(Error::custom("cannot merge entry with array")),
+            Value::Table(_) => Err(Error::custom("cannot merge table with array")),
+            Value::Array(array) => self.merge(array),
+        }
+    }
+}
+
+impl Default for Array {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Debug for Array {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(formatter)
+    }
+}
+
+impl Serialize for Array {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+
+        for element in &self.0 {
+            seq.serialize_element(&element)?;
+        }
+
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Array {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        pub struct ArrayVisitor;
+
+        impl<'de> Visitor<'de> for ArrayVisitor {
+            type Value = Array;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid array")
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Array(vec))
+            }
+        }
+
+        deserializer.deserialize_any(ArrayVisitor)
+    }
+}
+
+impl IntoIterator for Array {
+    type Item = Value;
+    type IntoIter = IntoIter<Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Array {
+    type Item = &'a Value;
+    type IntoIter = Iter<'a, Value>;
+
+    fn into_iter(self) -> Iter<'a, Value> {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Array {
+    type Item = &'a mut Value;
+    type IntoIter = IterMut<'a, Value>;
+
+    fn into_iter(self) -> IterMut<'a, Value> {
+        self.0.iter_mut()
+    }
+}
+
+impl From<Vec<Value>> for Array {
+    fn from(vec: Vec<Value>) -> Self {
+        Self(vec)
+    }
+}

--- a/crates/brace-config/src/lib/value/array.rs
+++ b/crates/brace-config/src/lib/value/array.rs
@@ -129,6 +129,17 @@ impl Array {
         }
     }
 
+    pub fn set_default<T>(&mut self, key: &str, value: T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        if self.get_value(key).is_err() {
+            self.set(key, value)?;
+        }
+
+        Ok(())
+    }
+
     pub fn set_value(&mut self, key: &str, value: Value) -> Result<(), Error> {
         let keys: Vec<&str> = key.splitn(3, '.').collect();
 
@@ -179,6 +190,14 @@ impl Array {
         }
     }
 
+    pub fn set_value_default(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        if self.get_value(key).is_err() {
+            self.set_value(key, value)?;
+        }
+
+        Ok(())
+    }
+
     pub fn merge(&mut self, array: &Self) -> Result<(), Error> {
         for (idx, val) in array.0.iter().enumerate() {
             match self.0.get_mut(idx) {
@@ -194,11 +213,34 @@ impl Array {
         Ok(())
     }
 
+    pub fn merge_default(&mut self, array: &Self) -> Result<(), Error> {
+        for (idx, val) in array.0.iter().enumerate() {
+            match self.0.get_mut(idx) {
+                Some(item) => {
+                    item.merge_default(&val)?;
+                }
+                None => {
+                    self.0.push(val.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn merge_value(&mut self, value: &Value) -> Result<(), Error> {
         match value {
             Value::Entry(_) => Err(Error::custom("cannot merge entry with array")),
             Value::Table(_) => Err(Error::custom("cannot merge table with array")),
             Value::Array(array) => self.merge(array),
+        }
+    }
+
+    pub fn merge_value_default(&mut self, value: &Value) -> Result<(), Error> {
+        match value {
+            Value::Entry(_) => Err(Error::custom("cannot merge entry with array")),
+            Value::Table(_) => Err(Error::custom("cannot merge table with array")),
+            Value::Array(array) => self.merge_default(array),
         }
     }
 }

--- a/crates/brace-config/src/lib/value/de.rs
+++ b/crates/brace-config/src/lib/value/de.rs
@@ -1,0 +1,312 @@
+use std::error::Error as StdError;
+use std::fmt::{self, Display};
+
+use serde::de::value::{MapDeserializer, SeqDeserializer};
+use serde::de::{Deserializer, Error as DeError, Visitor};
+use serde::forward_to_deserialize_any;
+
+use super::Value;
+use crate::value::array::Array;
+use crate::value::entry::Entry;
+use crate::value::table::Table;
+
+pub struct ValueDeserializer<'de>(&'de Value);
+
+impl<'de> ValueDeserializer<'de> {
+    pub fn new(value: &'de Value) -> Self {
+        Self(value)
+    }
+
+    pub fn deserialize_entry<V>(self, entry: &'de Entry, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_str(&entry.0)
+    }
+
+    pub fn deserialize_array<V>(self, array: &'de Array, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut deserializer = SeqDeserializer::new(array.into_iter());
+        let seq = visitor.visit_seq(&mut deserializer)?;
+
+        deserializer.end()?;
+
+        Ok(seq)
+    }
+
+    pub fn deserialize_table<V>(self, table: &'de Table, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let iter = table
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value));
+        let mut deserializer = MapDeserializer::new(iter);
+        let map = visitor.visit_map(&mut deserializer)?;
+
+        deserializer.end()?;
+
+        Ok(map)
+    }
+}
+
+impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Entry(entry) => self.deserialize_entry(entry, visitor),
+            Value::Array(array) => self.deserialize_array(array, visitor),
+            Value::Table(table) => self.deserialize_table(table, visitor),
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as bool")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as bool")),
+            Value::Entry(entry) => match entry.0.parse::<bool>() {
+                Ok(value) => visitor.visit_bool(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as i8")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as i8")),
+            Value::Entry(entry) => match entry.0.parse::<i8>() {
+                Ok(value) => visitor.visit_i8(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as i16")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as i16")),
+            Value::Entry(entry) => match entry.0.parse::<i16>() {
+                Ok(value) => visitor.visit_i16(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as i32")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as i32")),
+            Value::Entry(entry) => match entry.0.parse::<i32>() {
+                Ok(value) => visitor.visit_i32(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as i64")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as i64")),
+            Value::Entry(entry) => match entry.0.parse::<i64>() {
+                Ok(value) => visitor.visit_i64(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as i128")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as i128")),
+            Value::Entry(entry) => match entry.0.parse::<i128>() {
+                Ok(value) => visitor.visit_i128(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as u8")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as u8")),
+            Value::Entry(entry) => match entry.0.parse::<u8>() {
+                Ok(value) => visitor.visit_u8(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as u16")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as u16")),
+            Value::Entry(entry) => match entry.0.parse::<u16>() {
+                Ok(value) => visitor.visit_u16(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as u32")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as u32")),
+            Value::Entry(entry) => match entry.0.parse::<u32>() {
+                Ok(value) => visitor.visit_u32(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as u64")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as u64")),
+            Value::Entry(entry) => match entry.0.parse::<u64>() {
+                Ok(value) => visitor.visit_u64(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as u128")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as u128")),
+            Value::Entry(entry) => match entry.0.parse::<u128>() {
+                Ok(value) => visitor.visit_u128(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as f32")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as f32")),
+            Value::Entry(entry) => match entry.0.parse::<f32>() {
+                Ok(value) => visitor.visit_f32(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as f64")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as f64")),
+            Value::Entry(entry) => match entry.0.parse::<f64>() {
+                Ok(value) => visitor.visit_f64(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as char")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as char")),
+            Value::Entry(entry) => match entry.0.parse::<char>() {
+                Ok(value) => visitor.visit_char(value),
+                Err(err) => Err(Error::custom(format!("{}", err))),
+            },
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as str")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as str")),
+            Value::Entry(entry) => visitor.visit_str(&entry.0),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Array(_) => Err(Error::custom("cannot deserialize array variant as string")),
+            Value::Table(_) => Err(Error::custom("cannot deserialize table variant as string")),
+            Value::Entry(entry) => visitor.visit_str(&entry.0),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error(String);
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        "deserialization error"
+    }
+}
+
+impl DeError for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self(msg.to_string())
+    }
+}

--- a/crates/brace-config/src/lib/value/entry.rs
+++ b/crates/brace-config/src/lib/value/entry.rs
@@ -1,0 +1,212 @@
+use std::fmt::{self, Debug};
+
+use serde::de::{Deserialize, Deserializer, Visitor};
+use serde::ser::{Serialize, Serializer};
+
+use super::{Error, Value};
+
+#[derive(Clone, PartialEq)]
+pub struct Entry(pub(crate) String);
+
+impl Entry {
+    pub fn new() -> Self {
+        Self(String::new())
+    }
+
+    pub fn merge(&mut self, entry: &Self) -> Result<(), Error> {
+        self.0 = entry.0.clone();
+
+        Ok(())
+    }
+
+    pub fn merge_value(&mut self, value: &Value) -> Result<(), Error> {
+        match value {
+            Value::Array(_) => Err(Error::custom("cannot merge array with entry")),
+            Value::Table(_) => Err(Error::custom("cannot merge table with entry")),
+            Value::Entry(entry) => self.merge(entry),
+        }
+    }
+}
+
+impl Default for Entry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Debug for Entry {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(formatter)
+    }
+}
+
+impl Serialize for Entry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Entry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        pub struct EntryVisitor;
+
+        impl<'de> Visitor<'de> for EntryVisitor {
+            type Value = Entry;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid entry")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_i128<E>(self, value: i128) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_f32<E>(self, value: f32) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_char<E>(self, value: char) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+                Ok(Entry::from(value))
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+        }
+
+        deserializer.deserialize_any(EntryVisitor)
+    }
+}
+
+impl From<bool> for Entry {
+    fn from(value: bool) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<i8> for Entry {
+    fn from(value: i8) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<i16> for Entry {
+    fn from(value: i16) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<i32> for Entry {
+    fn from(value: i32) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<i64> for Entry {
+    fn from(value: i64) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<i128> for Entry {
+    fn from(value: i128) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<u8> for Entry {
+    fn from(value: u8) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<u16> for Entry {
+    fn from(value: u16) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<u32> for Entry {
+    fn from(value: u32) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<u64> for Entry {
+    fn from(value: u64) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<u128> for Entry {
+    fn from(value: u128) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<f32> for Entry {
+    fn from(value: f32) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<f64> for Entry {
+    fn from(value: f64) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<char> for Entry {
+    fn from(value: char) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<&str> for Entry {
+    fn from(value: &str) -> Self {
+        Entry(value.to_string())
+    }
+}
+
+impl From<String> for Entry {
+    fn from(value: String) -> Self {
+        Entry(value)
+    }
+}

--- a/crates/brace-config/src/lib/value/mod.rs
+++ b/crates/brace-config/src/lib/value/mod.rs
@@ -2,12 +2,15 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display};
 
-use serde::de::{Deserialize, Deserializer, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+use serde::de::{
+    Deserialize, DeserializeOwned, Deserializer, IntoDeserializer, MapAccess, SeqAccess, Visitor,
+};
 use serde::ser::{Serialize, Serializer};
 
 use self::array::Array;
 use self::de::{Error as DeError, ValueDeserializer};
 use self::entry::Entry;
+use self::ser::ValueSerializer;
 use self::table::Table;
 
 pub mod array;
@@ -15,6 +18,20 @@ pub mod de;
 pub mod entry;
 pub mod ser;
 pub mod table;
+
+pub fn from_value<T>(value: Value) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+{
+    T::deserialize(ValueDeserializer::new(&value)).map_err(Error::custom)
+}
+
+pub fn to_value<T>(value: T) -> Result<Value, Error>
+where
+    T: Serialize,
+{
+    value.serialize(ValueSerializer).map_err(Error::custom)
+}
 
 #[derive(Clone, PartialEq)]
 pub enum Value {

--- a/crates/brace-config/src/lib/value/mod.rs
+++ b/crates/brace-config/src/lib/value/mod.rs
@@ -1,0 +1,546 @@
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::fmt::{self, Debug, Display};
+
+use serde::de::{Deserialize, Deserializer, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+use serde::ser::{Serialize, Serializer};
+
+use self::array::Array;
+use self::de::{Error as DeError, ValueDeserializer};
+use self::entry::Entry;
+use self::table::Table;
+
+pub mod array;
+pub mod de;
+pub mod entry;
+pub mod ser;
+pub mod table;
+
+#[derive(Clone, PartialEq)]
+pub enum Value {
+    Entry(Entry),
+    Array(Array),
+    Table(Table),
+}
+
+impl Value {
+    pub fn entry() -> Self {
+        Value::Entry(Entry::new())
+    }
+
+    pub fn table() -> Self {
+        Value::Table(Table::new())
+    }
+
+    pub fn array() -> Self {
+        Value::Array(Array::new())
+    }
+
+    pub fn val<'de, T>(&'de self) -> Result<T, Error>
+    where
+        T: 'de + Deserialize<'de>,
+    {
+        T::deserialize(ValueDeserializer::new(self)).map_err(Error::custom)
+    }
+
+    pub fn get<'de, T>(&'de self, key: &str) -> Result<T, Error>
+    where
+        T: 'de + Deserialize<'de>,
+    {
+        match self {
+            Value::Entry(_) => Err(Error::custom("cannot call `get` on entry")),
+            Value::Array(array) => array.get(key),
+            Value::Table(table) => table.get(key),
+        }
+    }
+
+    pub fn get_value(&self, key: &str) -> Result<&Value, Error> {
+        match self {
+            Value::Entry(_) => Err(Error::custom("cannot call `get_value` on entry")),
+            Value::Array(array) => array.get_value(key),
+            Value::Table(table) => table.get_value(key),
+        }
+    }
+
+    pub fn set<T>(&mut self, key: &str, value: T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        match self {
+            Value::Entry(_) => Err(Error::custom("cannot call `set` on entry variant")),
+            Value::Array(array) => array.set(key, value),
+            Value::Table(table) => table.set(key, value),
+        }
+    }
+
+    pub fn set_value(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        match self {
+            Value::Entry(_) => Err(Error::custom("cannot call `set_value` on entry variant")),
+            Value::Array(array) => array.set_value(key, value),
+            Value::Table(table) => table.set_value(key, value),
+        }
+    }
+
+    pub fn merge(&mut self, value: &Self) -> Result<(), Error> {
+        match self {
+            Value::Entry(entry) => entry.merge_value(value),
+            Value::Array(array) => array.merge_value(value),
+            Value::Table(table) => table.merge_value(value),
+        }
+    }
+
+    pub fn merge_value(&mut self, value: &Value) -> Result<(), Error> {
+        self.merge(value)
+    }
+
+    pub fn as_entry(&self) -> Option<&Entry> {
+        match self {
+            Value::Entry(entry) => Some(entry),
+            Value::Array(_) => None,
+            Value::Table(_) => None,
+        }
+    }
+
+    pub fn as_array(&self) -> Option<&Array> {
+        match self {
+            Value::Entry(_) => None,
+            Value::Array(array) => Some(array),
+            Value::Table(_) => None,
+        }
+    }
+
+    pub fn as_table(&self) -> Option<&Table> {
+        match self {
+            Value::Entry(_) => None,
+            Value::Array(_) => None,
+            Value::Table(table) => Some(table),
+        }
+    }
+}
+
+impl Debug for Value {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Value::Entry(entry) => entry.fmt(formatter),
+            Value::Array(array) => array.fmt(formatter),
+            Value::Table(table) => table.fmt(formatter),
+        }
+    }
+}
+
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Value::Entry(entry) => entry.serialize(serializer),
+            Value::Array(array) => array.serialize(serializer),
+            Value::Table(table) => table.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        pub struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid value")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_i128<E>(self, value: i128) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_f32<E>(self, value: f32) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Value, E> {
+                Ok(Value::from(value))
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Value::from(vec))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut map = HashMap::new();
+
+                while let Some(key) = visitor.next_key()? {
+                    map.insert(key, visitor.next_value()?);
+                }
+
+                Ok(Value::from(map))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+impl<'de> IntoDeserializer<'de, DeError> for &'de Value {
+    type Deserializer = ValueDeserializer<'de>;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        ValueDeserializer::new(self)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<i8> for Value {
+    fn from(value: i8) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<i16> for Value {
+    fn from(value: i16) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<i32> for Value {
+    fn from(value: i32) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<i128> for Value {
+    fn from(value: i128) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<u8> for Value {
+    fn from(value: u8) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<u16> for Value {
+    fn from(value: u16) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<u128> for Value {
+    fn from(value: u128) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<f32> for Value {
+    fn from(value: f32) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<char> for Value {
+    fn from(value: char) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::Entry(Entry::from(value))
+    }
+}
+
+impl From<Vec<Value>> for Value {
+    fn from(value: Vec<Value>) -> Self {
+        Value::Array(Array::from(value))
+    }
+}
+
+impl From<HashMap<String, Value>> for Value {
+    fn from(value: HashMap<String, Value>) -> Self {
+        Value::Table(Table::from(value))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error(String);
+
+impl Error {
+    pub fn custom<T: Display>(msg: T) -> Self {
+        Self(msg.to_string())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        "value error"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::Value;
+
+    #[test]
+    fn test_boolean() {
+        let mut table = Value::table();
+
+        assert!(table.set("true", true).is_ok());
+        assert!(table.set("false", false).is_ok());
+        assert_eq!(table.get::<bool>("true").unwrap(), true);
+        assert_eq!(table.get::<bool>("false").unwrap(), false);
+    }
+
+    #[test]
+    fn test_integer_signed() {
+        let mut table = Value::table();
+
+        assert!(table.set("i8", 8 as i8).is_ok());
+        assert!(table.set("i16", 16 as i16).is_ok());
+        assert!(table.set("i32", 32 as i32).is_ok());
+        assert!(table.set("i64", 64 as i64).is_ok());
+        assert!(table.set("i128", 128 as i128).is_ok());
+
+        assert_eq!(table.get::<i8>("i8").unwrap(), 8);
+        assert_eq!(table.get::<i16>("i8").unwrap(), 8);
+        assert_eq!(table.get::<i32>("i8").unwrap(), 8);
+        assert_eq!(table.get::<i64>("i8").unwrap(), 8);
+        assert_eq!(table.get::<i128>("i8").unwrap(), 8);
+        assert_eq!(table.get::<String>("i8").unwrap(), "8");
+    }
+
+    #[test]
+    fn test_integer_unsigned() {
+        let mut table = Value::table();
+
+        assert!(table.set("u8", 8 as u8).is_ok());
+        assert!(table.set("u16", 16 as u16).is_ok());
+        assert!(table.set("u32", 32 as u32).is_ok());
+        assert!(table.set("u64", 64 as u64).is_ok());
+        assert!(table.set("u128", 128 as u128).is_ok());
+
+        assert_eq!(table.get::<u8>("u8").unwrap(), 8);
+        assert_eq!(table.get::<u16>("u8").unwrap(), 8);
+        assert_eq!(table.get::<u32>("u8").unwrap(), 8);
+        assert_eq!(table.get::<u64>("u8").unwrap(), 8);
+        assert_eq!(table.get::<u128>("u8").unwrap(), 8);
+        assert_eq!(table.get::<String>("u8").unwrap(), "8");
+    }
+
+    #[test]
+    fn test_float() {
+        let mut table = Value::table();
+
+        assert!(table.set("f32", 32 as f32).is_ok());
+        assert!(table.set("f64", 64 as f64).is_ok());
+    }
+
+    #[test]
+    fn test_text() {
+        let mut table = Value::table();
+
+        assert!(table.set("char", 'c').is_ok());
+        assert!(table.set("str", "str").is_ok());
+        assert!(table.set("string", String::from("string")).is_ok());
+
+        assert_eq!(table.get::<char>("char").unwrap(), 'c');
+        assert_eq!(table.get::<String>("char").unwrap(), "c".to_string());
+    }
+
+    #[test]
+    fn test_tuple() {
+        let mut table = Value::table();
+
+        assert!(table.set("tuple", ('a', "bee", 7, false)).is_ok());
+        assert!(table.get_value("tuple").unwrap().as_array().is_some());
+        assert!(table.get::<(char, String, usize, bool)>("tuple").is_ok());
+        assert!(table
+            .get::<(String, String, String, String)>("tuple")
+            .is_ok());
+        assert_eq!(
+            table
+                .get::<(String, String, String, String)>("tuple")
+                .unwrap(),
+            (
+                "a".to_string(),
+                "bee".to_string(),
+                "7".to_string(),
+                "false".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_struct() {
+        let mut table = Value::table();
+
+        #[derive(Serialize, Deserialize)]
+        struct A {
+            one: String,
+            two: HashMap<String, Vec<String>>,
+        }
+
+        let mut map = HashMap::<String, Vec<String>>::new();
+
+        map.insert(
+            "a".to_string(),
+            vec!["hello".to_string(), "world".to_string()],
+        );
+        map.insert("b".to_string(), Vec::new());
+
+        let a = A {
+            one: "one".to_string(),
+            two: map,
+        };
+
+        assert!(table.set("struct", a).is_ok());
+        assert!(table.get::<A>("struct").is_ok());
+        assert_eq!(table.get::<A>("struct").unwrap().one, "one".to_string());
+        assert_eq!(table.get::<A>("struct").unwrap().two.len(), 2);
+    }
+
+    #[test]
+    fn test_unit() {
+        let mut table = Value::table();
+
+        #[derive(Serialize, Deserialize)]
+        struct Unit;
+
+        assert!(table.set("unit", ()).is_err());
+        assert!(table.set("unit_struct", Unit).is_err());
+    }
+
+    #[test]
+    fn test_table() {
+        let mut table = Value::table();
+        let mut m1 = HashMap::<String, HashMap<String, String>>::new();
+        let mut m2 = HashMap::<String, String>::new();
+
+        m2.insert("g".to_string(), "h".to_string());
+        m1.insert("f".to_string(), m2);
+
+        assert!(table.set("a.b.c", "d").is_ok());
+        assert!(table.get::<HashMap<String, String>>("a.b").is_ok());
+        assert_eq!(table.get::<String>("a.b.c").unwrap(), "d");
+
+        assert!(table.set("e", m1).is_ok());
+        assert!(table.get::<HashMap<String, String>>("e.f").is_ok());
+        assert!(table
+            .get::<HashMap<String, HashMap<String, String>>>("e")
+            .is_ok());
+        assert_eq!(table.get::<String>("e.f.g").unwrap(), "h");
+    }
+
+    #[test]
+    fn test_array() {
+        let mut table = Value::table();
+
+        assert!(table.set("item.1", "a").is_err());
+        assert!(table.set("item.0", "b").is_ok());
+        assert!(table.set("item.1", "c").is_ok());
+
+        let mut array = Value::array();
+
+        assert!(array.set("1", "a").is_err());
+        assert!(array.set("0", "b").is_ok());
+        assert!(array.set("1", "c").is_ok());
+        assert!(array.set("d", "d").is_err());
+
+        assert!(table.set("array", array).is_ok());
+        assert!(table.get::<Vec<String>>("array").is_ok());
+        assert_eq!(table.get::<Vec<String>>("array").unwrap().len(), 2);
+    }
+}

--- a/crates/brace-config/src/lib/value/mod.rs
+++ b/crates/brace-config/src/lib/value/mod.rs
@@ -254,6 +254,24 @@ impl<'de> IntoDeserializer<'de, DeError> for &'de Value {
     }
 }
 
+impl From<Entry> for Value {
+    fn from(value: Entry) -> Self {
+        Value::Entry(value)
+    }
+}
+
+impl From<Array> for Value {
+    fn from(value: Array) -> Self {
+        Value::Array(value)
+    }
+}
+
+impl From<Table> for Value {
+    fn from(value: Table) -> Self {
+        Value::Table(value)
+    }
+}
+
 impl From<bool> for Value {
     fn from(value: bool) -> Self {
         Value::Entry(Entry::from(value))

--- a/crates/brace-config/src/lib/value/ser.rs
+++ b/crates/brace-config/src/lib/value/ser.rs
@@ -1,0 +1,562 @@
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::fmt::{self, Display};
+
+use serde::ser::{
+    Error as SerError, Impossible, Serialize, SerializeMap, SerializeSeq, SerializeStruct,
+    SerializeStructVariant, SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
+    Serializer,
+};
+
+use super::Value;
+
+pub struct ValueSerializer;
+
+impl Serializer for ValueSerializer {
+    type Ok = Value;
+    type Error = Error;
+    type SerializeSeq = ArraySeqSerializer;
+    type SerializeTuple = ArraySeqSerializer;
+    type SerializeTupleStruct = ArraySeqSerializer;
+    type SerializeTupleVariant = ArraySeqMatrixSerializer;
+    type SerializeMap = TableMapSerializer;
+    type SerializeStruct = TableMapSerializer;
+    type SerializeStructVariant = TableMapMatrixSerializer;
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_i128(self, value: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_u128(self, value: u128) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(value))
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported value type: byte array"))
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported value type: none option"))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported value type: unit"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported value type: unit struct"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::from(variant))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut map = HashMap::new();
+
+        map.insert(String::from(variant), value.serialize(self)?);
+
+        Ok(Value::from(map))
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+        Ok(ArraySeqSerializer {
+            seq: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Error> {
+        Ok(ArraySeqMatrixSerializer {
+            name: String::from(variant),
+            seq: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
+        Ok(TableMapSerializer {
+            map: HashMap::new(),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(TableMapMatrixSerializer {
+            name: String::from(variant),
+            map: HashMap::new(),
+        })
+    }
+}
+
+pub struct ArraySeqSerializer {
+    pub(crate) seq: Vec<Value>,
+}
+
+impl SerializeSeq for ArraySeqSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.seq.push(value.serialize(ValueSerializer)?);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, Error> {
+        Ok(Value::from(self.seq))
+    }
+}
+
+impl SerializeTuple for ArraySeqSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.seq.push(value.serialize(ValueSerializer)?);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, Error> {
+        Ok(Value::from(self.seq))
+    }
+}
+
+impl SerializeTupleStruct for ArraySeqSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.seq.push(value.serialize(ValueSerializer)?);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, Error> {
+        Ok(Value::from(self.seq))
+    }
+}
+
+pub struct ArraySeqMatrixSerializer {
+    pub(crate) name: String,
+    pub(crate) seq: Vec<Value>,
+}
+
+impl SerializeTupleVariant for ArraySeqMatrixSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.seq.push(value.serialize(ValueSerializer)?);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, Error> {
+        let mut map = HashMap::new();
+
+        map.insert(self.name, Value::from(self.seq));
+
+        Ok(Value::from(map))
+    }
+}
+
+pub struct TableMapSerializer {
+    pub(crate) map: HashMap<String, Value>,
+    pub(crate) next_key: Option<String>,
+}
+
+impl SerializeMap for TableMapSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.next_key = Some(key.serialize(TableKeySerializer)?);
+
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        let key = self.next_key.take();
+        let key = key.expect("serialize_value called before serialize_key");
+
+        self.map.insert(key, value.serialize(ValueSerializer)?);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, Error> {
+        Ok(Value::from(self.map))
+    }
+}
+
+impl SerializeStruct for TableMapSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        SerializeMap::serialize_key(self, key)?;
+        SerializeMap::serialize_value(self, value)?;
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        SerializeMap::end(self)
+    }
+}
+
+pub struct TableMapMatrixSerializer {
+    pub(crate) name: String,
+    pub(crate) map: HashMap<String, Value>,
+}
+
+impl SerializeStructVariant for TableMapMatrixSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.map
+            .insert(String::from(key), value.serialize(ValueSerializer)?);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, Error> {
+        let mut map = HashMap::new();
+
+        map.insert(self.name, Value::from(self.map));
+
+        Ok(Value::from(map))
+    }
+}
+
+pub struct TableKeySerializer;
+
+impl Serializer for TableKeySerializer {
+    type Ok = String;
+    type Error = Error;
+    type SerializeSeq = Impossible<String, Error>;
+    type SerializeTuple = Impossible<String, Error>;
+    type SerializeTupleStruct = Impossible<String, Error>;
+    type SerializeTupleVariant = Impossible<String, Error>;
+    type SerializeMap = Impossible<String, Error>;
+    type SerializeStruct = Impossible<String, Error>;
+    type SerializeStructVariant = Impossible<String, Error>;
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(variant.to_owned())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_bool(self, _value: bool) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: bool"))
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_f32(self, _value: f32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: f32"))
+    }
+
+    fn serialize_f64(self, _value: f64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: f64"))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_owned())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: bytes"))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: unit"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: unit struct"))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(Error::custom("unsupported key type: newtype variant"))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::custom("unsupported key type: none option"))
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(Error::custom("unsupported key type: some option"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Error::custom("unsupported key type: seq"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Error::custom("unsupported key type: tuple"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Error::custom("unsupported key type: tuple struct"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Error::custom("unsupported key type: tuple variant"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Error::custom("unsupported key type: map"))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Error::custom("unsupported key type: struct"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Error::custom("unsupported key type: variant"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error(String);
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        "serialization error"
+    }
+}
+
+impl SerError for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self(msg.to_string())
+    }
+}

--- a/crates/brace-config/src/lib/value/table.rs
+++ b/crates/brace-config/src/lib/value/table.rs
@@ -1,0 +1,282 @@
+use std::collections::hash_map::{HashMap, IntoIter, Iter, IterMut};
+use std::fmt::{self, Debug};
+
+use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+use serde::ser::{Serialize, Serializer};
+
+use super::{ser::ValueSerializer, Error, Value};
+
+#[derive(Clone, PartialEq)]
+pub struct Table(pub(crate) HashMap<String, Value>);
+
+impl Table {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn get<'de, T>(&'de self, key: &str) -> Result<T, Error>
+    where
+        T: 'de + Deserialize<'de>,
+    {
+        let keys: Vec<&str> = key.splitn(2, '.').collect();
+
+        if keys.is_empty() {
+            return Err(Error::custom("empty key"));
+        }
+
+        if keys.len() == 1 {
+            match self.0.get(key) {
+                Some(value) => value.val(),
+                None => Err(Error::custom(format!("missing value for '{}'", key))),
+            }
+        } else {
+            match self.0.get(keys[0]) {
+                Some(value) => value.get(keys[1]),
+                None => Err(Error::custom(format!("missing value for '{}'", key))),
+            }
+        }
+    }
+
+    pub fn get_value(&self, key: &str) -> Result<&Value, Error> {
+        let keys: Vec<&str> = key.splitn(2, '.').collect();
+
+        if keys.is_empty() {
+            Err(Error::custom("empty key"))
+        } else if keys.len() == 1 {
+            match self.0.get(key) {
+                Some(value) => Ok(value),
+                None => Err(Error::custom(format!("missing value for '{}'", key))),
+            }
+        } else {
+            match self.0.get(keys[0]) {
+                Some(value) => value.get_value(keys[1]),
+                None => Err(Error::custom(format!("missing value for '{}'", key))),
+            }
+        }
+    }
+
+    pub fn set<T>(&mut self, key: &str, value: T) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        let keys: Vec<&str> = key.splitn(3, '.').collect();
+
+        if keys.is_empty() {
+            return Err(Error::custom("empty key"));
+        }
+
+        let key = keys[0].to_string();
+
+        if keys.len() == 1 {
+            self.0.insert(
+                key,
+                value.serialize(ValueSerializer).map_err(Error::custom)?,
+            );
+
+            return Ok(());
+        }
+
+        let peek = keys[1].to_string();
+        let mut tail = keys[1].to_string();
+
+        if keys.len() == 3 {
+            tail.push('.');
+            tail.push_str(keys[2]);
+        }
+
+        match self.0.get_mut(keys[0]) {
+            Some(val) => match val {
+                Value::Entry(_) => Err(Error::custom("cannot insert into entry")),
+                Value::Array(array) => array.set(&tail, value),
+                Value::Table(table) => table.set(&tail, value),
+            },
+            None => {
+                match peek.parse::<usize>() {
+                    Ok(_) => {
+                        let mut array = Value::array();
+
+                        array.set(&tail, value)?;
+                        self.0.insert(key, array);
+                    }
+                    Err(_) => {
+                        let mut table = Value::table();
+
+                        table.set(&tail, value)?;
+                        self.0.insert(key, table);
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    pub fn set_value(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        let keys: Vec<&str> = key.splitn(3, '.').collect();
+
+        if keys.is_empty() {
+            return Err(Error::custom("empty key"));
+        }
+
+        let key = keys[0].to_string();
+
+        if keys.len() == 1 {
+            self.0.insert(key, value);
+
+            return Ok(());
+        }
+
+        let peek = keys[1].to_string();
+        let mut tail = keys[1].to_string();
+
+        if keys.len() == 3 {
+            tail.push_str(keys[2]);
+        }
+
+        match self.0.get_mut(&key) {
+            Some(val) => val.set_value(keys[1], value),
+            None => {
+                match peek.parse::<usize>() {
+                    Ok(_) => {
+                        let mut array = Value::array();
+
+                        array.set_value(&tail, value)?;
+                        self.0.insert(key, array);
+                    }
+                    Err(_) => {
+                        let mut table = Value::table();
+
+                        table.set_value(&tail, value)?;
+                        self.0.insert(key, table);
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    pub fn merge(&mut self, table: &Self) -> Result<(), Error> {
+        for (key, val) in &table.0 {
+            match self.0.get_mut(key) {
+                Some(item) => {
+                    item.merge(&val)?;
+                }
+                None => {
+                    self.0.insert(key.to_owned(), val.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn merge_value(&mut self, value: &Value) -> Result<(), Error> {
+        match value {
+            Value::Entry(_) => Err(Error::custom("cannot merge entry with table")),
+            Value::Array(_) => Err(Error::custom("cannot merge array with table")),
+            Value::Table(table) => self.merge(table),
+        }
+    }
+}
+
+impl Default for Table {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Debug for Table {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(formatter)
+    }
+}
+
+impl Serialize for Table {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+
+        for (key, value) in &self.0 {
+            map.serialize_entry(&key, &value)?;
+        }
+
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Table {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        pub struct TableVisitor;
+
+        impl<'de> Visitor<'de> for TableVisitor {
+            type Value = Table;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid table")
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut map = HashMap::new();
+
+                while let Some(key) = visitor.next_key()? {
+                    map.insert(key, visitor.next_value()?);
+                }
+
+                Ok(Table(map))
+            }
+        }
+
+        deserializer.deserialize_any(TableVisitor)
+    }
+}
+
+impl IntoIterator for Table {
+    type Item = (String, Value);
+    type IntoIter = IntoIter<String, Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Table {
+    type Item = (&'a String, &'a Value);
+    type IntoIter = Iter<'a, String, Value>;
+
+    fn into_iter(self) -> Iter<'a, String, Value> {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Table {
+    type Item = (&'a String, &'a mut Value);
+    type IntoIter = IterMut<'a, String, Value>;
+
+    fn into_iter(self) -> IterMut<'a, String, Value> {
+        self.0.iter_mut()
+    }
+}
+
+impl From<HashMap<String, Value>> for Table {
+    fn from(map: HashMap<String, Value>) -> Self {
+        Self(map)
+    }
+}

--- a/crates/brace-theme/Cargo.toml
+++ b/crates/brace-theme/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib/lib.rs"
 [dependencies]
 actix = "0.8.0-alpha.2"
 brace-cli = { path = "../brace-cli" }
+brace-config = { path = "../brace-config" }
 failure = "0.1"
 path-absolutize = "1.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/brace-theme/src/lib/config.rs
+++ b/crates/brace-theme/src/lib/config.rs
@@ -1,8 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use failure::Error;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::manifest::ManifestReferenceInfo;
 
@@ -12,21 +10,6 @@ pub struct ThemeConfig {
     pub theme: ThemeInfo,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub manifests: Vec<ManifestReferenceInfo>,
-}
-
-impl ThemeConfig {
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let string = std::fs::read_to_string(path)?;
-        let config = toml::from_str(&string)?;
-
-        Ok(config)
-    }
-
-    pub fn from_json(json: Value) -> Result<Self, Error> {
-        let config = serde_json::from_value(json)?;
-
-        Ok(config)
-    }
 }
 
 impl Default for ThemeConfig {

--- a/crates/brace-theme/src/lib/manifest.rs
+++ b/crates/brace-theme/src/lib/manifest.rs
@@ -1,8 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use failure::Error;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::library::LibraryInfo;
 use super::resource::ResourceInfo;
@@ -18,21 +16,6 @@ pub struct ManifestConfig {
     pub resources: Vec<ResourceInfo>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub templates: Vec<TemplateInfo>,
-}
-
-impl ManifestConfig {
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let string = std::fs::read_to_string(path)?;
-        let config = toml::from_str(&string)?;
-
-        Ok(config)
-    }
-
-    pub fn from_json(json: Value) -> Result<Self, Error> {
-        let config = serde_json::from_value(json)?;
-
-        Ok(config)
-    }
 }
 
 impl Default for ManifestConfig {

--- a/crates/brace-theme/src/lib/renderer/mod.rs
+++ b/crates/brace-theme/src/lib/renderer/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use actix::{Actor, Addr, SyncArbiter, SyncContext};
-use brace_config::file::load_from_file;
+use brace_config::load;
 use failure::{format_err, Error};
 use path_absolutize::Absolutize;
 use serde_json::Value;
@@ -30,12 +30,12 @@ impl Renderer {
 
         for theme in conf.themes {
             let path = theme.path;
-            let conf: ThemeConfig = load_from_file(&path)?;
+            let conf: ThemeConfig = load::file(&path)?;
 
             match path.parent() {
                 Some(dir) => {
                     for manifest in conf.manifests {
-                        let mut mcfg: ManifestConfig = load_from_file(&dir.join(manifest.path))?;
+                        let mut mcfg: ManifestConfig = load::file(&dir.join(manifest.path))?;
 
                         for template in mcfg.templates.iter_mut() {
                             match template {

--- a/crates/brace-theme/src/lib/renderer/mod.rs
+++ b/crates/brace-theme/src/lib/renderer/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use actix::{Actor, Addr, SyncArbiter, SyncContext};
+use brace_config::file::load_from_file;
 use failure::{format_err, Error};
 use path_absolutize::Absolutize;
 use serde_json::Value;
@@ -29,12 +30,12 @@ impl Renderer {
 
         for theme in conf.themes {
             let path = theme.path;
-            let conf = ThemeConfig::from_file(&path)?;
+            let conf: ThemeConfig = load_from_file(&path)?;
 
             match path.parent() {
                 Some(dir) => {
                     for manifest in conf.manifests {
-                        let mut mcfg = ManifestConfig::from_file(&dir.join(manifest.path))?;
+                        let mut mcfg: ManifestConfig = load_from_file(&dir.join(manifest.path))?;
 
                         for template in mcfg.templates.iter_mut() {
                             match template {

--- a/crates/brace/Cargo.toml
+++ b/crates/brace/Cargo.toml
@@ -19,6 +19,7 @@ actix-files = "0.1.0-alpha.1"
 actix-service = "0.3"
 actix-web = "1.0.0-alpha.2"
 brace-cli = { path = "../brace-cli" }
+brace-config = { path = "../brace-config" }
 brace-db = { path = "../brace-db" }
 brace-theme = { path = "../brace-theme" }
 brace-web = { path = "../brace-web" }

--- a/crates/brace/src/lib/cli/web/run.rs
+++ b/crates/brace/src/lib/cli/web/run.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use std::path::Path;
 
 use brace_cli::prelude::*;
-use brace_config::file::load_from_file;
+use brace_config::load;
 use failure::format_err;
 use path_absolutize::Absolutize;
 
@@ -37,7 +37,7 @@ pub fn cmd() -> Command {
 
 pub fn exec(shell: &mut Shell, matches: &ArgMatches) -> ExecResult {
     match matches.value_of("config") {
-        Some(file) => match load_from_file(file) {
+        Some(file) => match load::file(file) {
             Ok(config) => {
                 let config = overload_file(file, config, shell, matches)?;
 

--- a/crates/brace/src/lib/cli/web/run.rs
+++ b/crates/brace/src/lib/cli/web/run.rs
@@ -3,6 +3,7 @@ use std::net::Ipv4Addr;
 use std::path::Path;
 
 use brace_cli::prelude::*;
+use brace_config::file::load_from_file;
 use failure::format_err;
 use path_absolutize::Absolutize;
 
@@ -36,7 +37,7 @@ pub fn cmd() -> Command {
 
 pub fn exec(shell: &mut Shell, matches: &ArgMatches) -> ExecResult {
     match matches.value_of("config") {
-        Some(file) => match AppConfig::from_file(file) {
+        Some(file) => match load_from_file(file) {
             Ok(config) => {
                 let config = overload_file(file, config, shell, matches)?;
 

--- a/crates/brace/src/lib/config.rs
+++ b/crates/brace/src/lib/config.rs
@@ -1,10 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use brace_db::DatabaseConfig;
 use brace_theme::config::ThemeReferenceInfo;
 use brace_web::config::WebConfig;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
@@ -13,21 +12,6 @@ pub struct AppConfig {
     pub database: DatabaseConfig,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub themes: Vec<ThemeReferenceInfo>,
-}
-
-impl AppConfig {
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, failure::Error> {
-        let string = std::fs::read_to_string(path)?;
-        let config = toml::from_str(&string)?;
-
-        Ok(config)
-    }
-
-    pub fn from_json(json: Value) -> Result<Self, failure::Error> {
-        let config = serde_json::from_value(json)?;
-
-        Ok(config)
-    }
 }
 
 impl Default for AppConfig {

--- a/crates/brace/src/lib/lib.rs
+++ b/crates/brace/src/lib/lib.rs
@@ -5,6 +5,7 @@ use actix_web::middleware::Logger;
 use actix_web::web::{get, resource};
 use actix_web::App;
 use actix_web::HttpServer;
+use brace_config::file::load_from_file;
 use brace_db::Database;
 use brace_theme::config::ThemeConfig;
 use brace_theme::renderer::{Renderer, RendererConfig};
@@ -43,7 +44,7 @@ pub fn run(config: AppConfig, path: &Path) -> Result<(), Error> {
     let themes = config
         .themes
         .iter()
-        .filter_map(|theme| match ThemeConfig::from_file(&theme.path) {
+        .filter_map(|theme| match load_from_file(&theme.path) {
             Ok(conf) => Some((conf, theme.path.clone())),
             Err(_) => None,
         })

--- a/crates/brace/src/lib/lib.rs
+++ b/crates/brace/src/lib/lib.rs
@@ -5,7 +5,7 @@ use actix_web::middleware::Logger;
 use actix_web::web::{get, resource};
 use actix_web::App;
 use actix_web::HttpServer;
-use brace_config::file::load_from_file;
+use brace_config::{load, save};
 use brace_db::Database;
 use brace_theme::config::ThemeConfig;
 use brace_theme::renderer::{Renderer, RendererConfig};
@@ -26,7 +26,7 @@ pub fn init(config: AppConfig, path: &Path) -> Result<(), Error> {
     let path = get_dir(path)?;
 
     std::fs::create_dir_all(path.join("themes/default")).unwrap();
-    std::fs::write(path.join("config.toml"), toml::to_string_pretty(&config)?)?;
+    save::file(path.join("config.toml"), &config)?;
     brace_theme::init(ThemeConfig::default(), &path.join("themes/default")).unwrap();
 
     Ok(())
@@ -44,7 +44,7 @@ pub fn run(config: AppConfig, path: &Path) -> Result<(), Error> {
     let themes = config
         .themes
         .iter()
-        .filter_map(|theme| match load_from_file(&theme.path) {
+        .filter_map(|theme| match load::file(&theme.path) {
             Ok(conf) => Some((conf, theme.path.clone())),
             Err(_) => None,
         })

--- a/crates/brace/src/lib/route/resources.rs
+++ b/crates/brace/src/lib/route/resources.rs
@@ -12,6 +12,7 @@ use actix_web::dev::{
 };
 use actix_web::error::Error;
 use actix_web::{HttpRequest, Responder};
+use brace_config::file::load_from_file;
 use brace_theme::config::ThemeConfig;
 use brace_theme::manifest::ManifestConfig;
 use brace_theme::resource::ResourceInfo;
@@ -210,12 +211,10 @@ fn load_manifests(theme: ThemeConfig, path: &Path) -> Vec<ManifestConfig> {
     theme
         .manifests
         .iter()
-        .filter_map(
-            |manifest| match ManifestConfig::from_file(path.join(&manifest.path)) {
-                Ok(conf) => Some(conf),
-                Err(_) => None,
-            },
-        )
+        .filter_map(|manifest| match load_from_file(path.join(&manifest.path)) {
+            Ok(conf) => Some(conf),
+            Err(_) => None,
+        })
         .collect()
 }
 

--- a/crates/brace/src/lib/route/resources.rs
+++ b/crates/brace/src/lib/route/resources.rs
@@ -12,7 +12,7 @@ use actix_web::dev::{
 };
 use actix_web::error::Error;
 use actix_web::{HttpRequest, Responder};
-use brace_config::file::load_from_file;
+use brace_config::load;
 use brace_theme::config::ThemeConfig;
 use brace_theme::manifest::ManifestConfig;
 use brace_theme::resource::ResourceInfo;
@@ -211,7 +211,7 @@ fn load_manifests(theme: ThemeConfig, path: &Path) -> Vec<ManifestConfig> {
     theme
         .manifests
         .iter()
-        .filter_map(|manifest| match load_from_file(path.join(&manifest.path)) {
+        .filter_map(|manifest| match load::file(path.join(&manifest.path)) {
             Ok(conf) => Some(conf),
             Err(_) => None,
         })

--- a/crates/brace/src/lib/route/themes.rs
+++ b/crates/brace/src/lib/route/themes.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::Data;
 use actix_web::HttpResponse;
-use brace_config::file::load_from_file;
+use brace_config::load;
 use brace_theme::config::{ThemeConfig, ThemeInfo};
 use brace_theme::manifest::ManifestConfig;
 use brace_theme::renderer::{Renderer, Template};
@@ -20,7 +20,7 @@ pub fn get(
     let themes = conf
         .themes
         .iter()
-        .filter_map(|theme| match load_from_file(&theme.path) {
+        .filter_map(|theme| match load::file(&theme.path) {
             Ok(conf) => Some((conf, theme.path.as_path())),
             Err(_) => None,
         })
@@ -39,7 +39,7 @@ pub fn get(
                 .iter()
                 .filter_map(|manifest| match theme_path.parent() {
                     Some(parent) => {
-                        match load_from_file::<ManifestConfig, _>(parent.join(&manifest.path)) {
+                        match load::file::<ManifestConfig, _>(parent.join(&manifest.path)) {
                             Ok(manifest) => Some(
                                 manifest
                                     .resources

--- a/crates/brace/tests/web.rs
+++ b/crates/brace/tests/web.rs
@@ -15,7 +15,7 @@ fn test_web_server_without_config() {
         .spawn()
         .unwrap();
 
-    sleep(Duration::from_millis(200));
+    sleep(Duration::from_millis(500));
 
     let res1 = reqwest::get("http://127.0.0.1:8080");
     let res2 = reqwest::get("http://127.0.0.1:8080/themes");
@@ -37,7 +37,7 @@ fn test_web_server_with_arguments() {
         .spawn()
         .unwrap();
 
-    sleep(Duration::from_millis(200));
+    sleep(Duration::from_millis(500));
 
     let res1 = reqwest::get("http://127.0.0.1:8001");
     let res2 = reqwest::get("http://127.0.0.1:8001/themes");
@@ -71,7 +71,7 @@ fn test_web_server_with_config() {
         .spawn()
         .unwrap();
 
-    sleep(Duration::from_millis(200));
+    sleep(Duration::from_millis(500));
 
     let res1 = reqwest::get("http://127.0.0.1:8002");
     let res2 = reqwest::get("http://127.0.0.1:8002/themes");


### PR DESCRIPTION
This adds a generic configuration management system for reading/writing configuration data from/to _toml_, _yaml_ and _json_ files (#18). The codebase has been partially updated to use the new file loading mechanism and a follow-up pull request should be made to complete the integration with the generic configuration system.