### PR TITLE
Add configuration macros

### DIFF
--- a/crates/brace-config/src/lib/config.rs
+++ b/crates/brace-config/src/lib/config.rs
@@ -81,6 +81,12 @@ impl Default for Config {
     }
 }
 
+impl From<Table> for Config {
+    fn from(value: Table) -> Self {
+        Self(value)
+    }
+}
+
 pub struct ImmutableConfig(Config);
 
 impl ImmutableConfig {

--- a/crates/brace-config/src/lib/lib.rs
+++ b/crates/brace-config/src/lib/lib.rs
@@ -4,6 +4,9 @@ pub use self::value::entry::Entry;
 pub use self::value::table::Table;
 pub use self::value::{from_value, to_value, Value};
 
+#[macro_use]
+mod macros;
+
 pub mod config;
 pub mod load;
 pub mod save;

--- a/crates/brace-config/src/lib/macros.rs
+++ b/crates/brace-config/src/lib/macros.rs
@@ -1,0 +1,224 @@
+#[macro_export]
+macro_rules! value {
+    ([]) => {
+        $crate::Value::array()
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Value::from($crate::array!($($tt)+))
+    };
+
+    ({}) => {
+        $crate::Value::table()
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Value::from($crate::table!($($tt)+))
+    };
+
+    ($other:expr) => {
+        $crate::to_value(&$other).unwrap()
+    };
+}
+
+#[macro_export]
+macro_rules! array {
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        std::vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        std::vec![$($elems),*]
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        $crate::array!(@array [$($elems,)* $crate::value!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a table.
+    (@array [$($elems:expr,)*] {$($table:tt)*} $($rest:tt)*) => {
+        $crate::array!(@array [$($elems,)* $crate::value!({$($table)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        $crate::array!(@array [$($elems,)* $crate::value!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        $crate::array!(@array [$($elems,)* $crate::value!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        $crate::array!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        $crate::value_unexpected!($unexpected)
+    };
+
+    () => {
+        $crate::Array::new()
+    };
+
+    ( $($tt:tt)+ ) => {
+        $crate::Array::from($crate::array!(@array [] $($tt)+))
+    };
+}
+
+#[macro_export]
+macro_rules! table {
+    // Done.
+    (@table $table:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@table $table:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        $table.insert(($($key)+).into(), $value);
+        $crate::table!(@table $table () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@table $table:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        $crate::value_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@table $table:ident [$($key:tt)+] ($value:expr)) => {
+        $table.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is an array.
+    (@table $table:ident ($($key:tt)+) (= [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        $crate::table!(@table $table [$($key)+] ($crate::value!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a table.
+    (@table $table:ident ($($key:tt)+) (= {$($next_table:tt)*} $($rest:tt)*) $copy:tt) => {
+        $crate::table!(@table $table [$($key)+] ($crate::value!({$($next_table)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@table $table:ident ($($key:tt)+) (= $value:expr , $($rest:tt)*) $copy:tt) => {
+        $crate::table!(@table $table [$($key)+] ($crate::value!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@table $table:ident ($($key:tt)+) (= $value:expr) $copy:tt) => {
+        $crate::table!(@table $table [$($key)+] ($crate::value!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@table $table:ident ($($key:tt)+) (=) $copy:tt) => {
+        $crate::value_unexpected!("");
+    };
+
+    // Missing assignment for last entry. Trigger a reasonable error message.
+    (@table $table:ident ($($key:tt)+) () $copy:tt) => {
+        $crate::value_unexpected!("");
+    };
+
+    // Misplaced assignment. Trigger a reasonable error message.
+    (@table $table:ident () (= $($rest:tt)*) ($unexpected:tt $($copy:tt)*)) => {
+        $crate::value_unexpected!($unexpected);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@table $table:ident ($($key:tt)*) (, $($rest:tt)*) ($unexpected:tt $($copy:tt)*)) => {
+        $crate::value_unexpected!($unexpected);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false positives because the
+    // parenthesization may be necessary here.
+    (@table $table:ident () (($key:expr) = $($rest:tt)*) $copy:tt) => {
+        $crate::table!(@table $table ($key) (= $($rest)*) (= $($rest)*));
+    };
+
+    // Munch a token into the current key.
+    (@table $table:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        $crate::table!(@table $table ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    () => {
+        $crate::Table::new()
+    };
+
+    ( $($tt:tt)+ ) => {
+        {
+            let mut table = std::collections::HashMap::new();
+            $crate::table!(@table table () ($($tt)+) ($($tt)+));
+            $crate::Table::from(table)
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! value_unexpected {
+    () => {};
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_value() {
+        let entry = value!("entry");
+        let array = value!(["array"]);
+        let table = value!({ "table" = true });
+
+        assert_eq!(entry.val::<String>().unwrap(), "entry");
+        assert_eq!(array.get::<String>("0").unwrap(), "array");
+        assert_eq!(table.get::<bool>("table").unwrap(), true);
+    }
+
+    #[test]
+    fn test_array() {
+        let array1 = array![];
+        let array2 = array![[]];
+        let array3 = array![{}];
+        let array4 = array!["a"];
+        let array5 = array![[], {}, "a"];
+        let array6 = array!['a', "b", ("c", "d")];
+
+        assert_eq!(array1.0.len(), 0);
+        assert_eq!(array2.0.len(), 1);
+        assert_eq!(array3.0.len(), 1);
+        assert_eq!(array4.0.len(), 1);
+        assert_eq!(array5.0.len(), 3);
+        assert_eq!(array6.0.len(), 3);
+    }
+
+    #[test]
+    fn test_table() {
+        let t = table! {
+            "a" = "a",
+            "b" = "b",
+            "c" = {},
+            "d" = [],
+            "e" = ['f', "g", ("h", "i", true)],
+            "j" = {
+                "k" = "l",
+                "m" = {
+                    "n" = ["o", "p"],
+                },
+            },
+            "q" = ("r", "s"),
+        };
+
+        assert_eq!(t.get::<String>("a").unwrap(), "a");
+        assert_eq!(t.get::<String>("b").unwrap(), "b");
+        assert!(t.get_value("c").unwrap().as_table().unwrap().0.is_empty());
+        assert!(t.get_value("d").unwrap().as_array().unwrap().0.is_empty());
+        assert_eq!(t.get_value("e").unwrap().as_array().unwrap().0.len(), 3);
+        assert_eq!(t.get_value("e.2").unwrap().as_array().unwrap().0.len(), 3);
+        assert_eq!(t.get::<String>("e.2.1").unwrap(), "i");
+        assert_eq!(t.get::<String>("j.k").unwrap(), "l");
+        assert_eq!(t.get::<String>("j.m.n.0").unwrap(), "o");
+        assert_eq!(t.get::<String>("q.0").unwrap(), "r");
+    }
+}

--- a/crates/brace-config/src/lib/macros.rs
+++ b/crates/brace-config/src/lib/macros.rs
@@ -1,4 +1,15 @@
 #[macro_export]
+macro_rules! config {
+    () => {
+        $crate::Config::new()
+    };
+
+    ( $($tt:tt)+ ) => {
+        $crate::Config::from($crate::table!($($tt)+))
+    };
+}
+
+#[macro_export]
 macro_rules! value {
     ([]) => {
         $crate::Value::array()
@@ -165,6 +176,15 @@ macro_rules! value_unexpected {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_config() {
+        let config1 = config! { "key" = "value" };
+        let config2 = config! {};
+
+        assert_eq!(config1.get::<String>("key").unwrap(), "value");
+        assert!(config2.get::<String>("key").is_err());
+    }
+
     #[test]
     fn test_value() {
         let entry = value!("entry");

--- a/crates/brace/tests/web.rs
+++ b/crates/brace/tests/web.rs
@@ -15,7 +15,7 @@ fn test_web_server_without_config() {
         .spawn()
         .unwrap();
 
-    sleep(Duration::from_millis(500));
+    sleep(Duration::from_millis(5000));
 
     let res1 = reqwest::get("http://127.0.0.1:8080");
     let res2 = reqwest::get("http://127.0.0.1:8080/themes");
@@ -37,7 +37,7 @@ fn test_web_server_with_arguments() {
         .spawn()
         .unwrap();
 
-    sleep(Duration::from_millis(500));
+    sleep(Duration::from_millis(5000));
 
     let res1 = reqwest::get("http://127.0.0.1:8001");
     let res2 = reqwest::get("http://127.0.0.1:8001/themes");
@@ -71,7 +71,7 @@ fn test_web_server_with_config() {
         .spawn()
         .unwrap();
 
-    sleep(Duration::from_millis(500));
+    sleep(Duration::from_millis(5000));
 
     let res1 = reqwest::get("http://127.0.0.1:8002");
     let res2 = reqwest::get("http://127.0.0.1:8002/themes");


### PR DESCRIPTION
This adds configuration macros inspired by the _serde_json::json!_ macro. The key difference here is that there are four separate macros and assignment is done via the _=_ character rather than the _:_ character.