### PR TITLE
Add a user authentication system, part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonwebtoken 6.0.0 (git+https://github.com/Keats/jsonwebtoken.git?rev=0ccb61eea51e1384eadb1d3dff7b40765a89f464)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1225,6 +1226,20 @@ dependencies = [
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jsonwebtoken"
+version = "6.0.0"
+source = "git+https://github.com/Keats/jsonwebtoken.git?rev=0ccb61eea51e1384eadb1d3dff7b40765a89f464#0ccb61eea51e1384eadb1d3dff7b40765a89f464"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -2921,6 +2936,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum jsonwebtoken 6.0.0 (git+https://github.com/Keats/jsonwebtoken.git?rev=0ccb61eea51e1384eadb1d3dff7b40765a89f464)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/crates/brace-web-auth/Cargo.toml
+++ b/crates/brace-web-auth/Cargo.toml
@@ -23,6 +23,7 @@ brace-web = { path = "../brace-web" }
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1"
 futures = "0.1"
+jsonwebtoken = { git = "https://github.com/Keats/jsonwebtoken.git", rev = "0ccb61eea51e1384eadb1d3dff7b40765a89f464" }
 rand = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/brace-web-auth/src/lib/route/api/auth.rs
+++ b/crates/brace-web-auth/src/lib/route/api/auth.rs
@@ -1,0 +1,33 @@
+use actix_web::error::Error;
+use actix_web::web::{Data, Json};
+use actix_web::HttpResponse;
+use brace_db::Database;
+use futures::future::Future;
+use serde_json::json;
+
+use crate::model::UserAuth;
+use crate::util::{create_token, verify};
+
+pub fn post(
+    data: Json<UserAuth>,
+    database: Data<Database>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    crate::action::locate::locate(&database, data.email.clone()).then(move |res| {
+        if let Ok(user) = res {
+            if let Ok(is_match) = verify(&data.password, &user.password) {
+                if is_match {
+                    if let Ok(token) = create_token(user.into()) {
+                        return HttpResponse::Ok().json(json!({ "token": token }));
+                    }
+                }
+            }
+        }
+
+        HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish()
+    })
+}

--- a/crates/brace-web-auth/src/lib/route/api/create.rs
+++ b/crates/brace-web-auth/src/lib/route/api/create.rs
@@ -3,22 +3,33 @@ use actix_web::http::header;
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use futures::future::{ok, Either, Future};
 use serde_json::json;
 
-use crate::model::User;
+use crate::model::{CurrentAuth, User};
 
 pub fn create(
+    auth: CurrentAuth,
     database: Data<Database>,
     user: Json<User>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::create::create(&database, user.into_inner())
-        .map_err(ErrorInternalServerError)
-        .and_then(|user| {
-            HttpResponse::Created()
-                .header(header::LOCATION, format!("/api/users/{}", user.id))
-                .json(json!({
-                    "value": user,
-                }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::create::create(&database, user.into_inner())
+                .map_err(ErrorInternalServerError)
+                .and_then(|user| {
+                    HttpResponse::Created()
+                        .header(header::LOCATION, format!("/api/users/{}", user.id))
+                        .json(json!({
+                            "value": user,
+                        }))
+                }),
+        ),
+    }
 }

--- a/crates/brace-web-auth/src/lib/route/api/delete.rs
+++ b/crates/brace-web-auth/src/lib/route/api/delete.rs
@@ -2,22 +2,35 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::{Data, Path};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use futures::future::{ok, Either, Future};
 use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
+use crate::model::CurrentAuth;
+
 pub fn delete(
+    auth: CurrentAuth,
     database: Data<Database>,
     path: Path<Info>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::delete::delete(&database, path.user)
-        .map_err(ErrorInternalServerError)
-        .and_then(|user| {
-            HttpResponse::Ok().json(json!({
-                "value": user,
-            }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::delete::delete(&database, path.user)
+                .map_err(ErrorInternalServerError)
+                .and_then(|user| {
+                    HttpResponse::Ok().json(json!({
+                        "value": user,
+                    }))
+                }),
+        ),
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/brace-web-auth/src/lib/route/api/list.rs
+++ b/crates/brace-web-auth/src/lib/route/api/list.rs
@@ -2,15 +2,30 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::Data;
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use futures::future::{ok, Either, Future};
 use serde_json::json;
 
-pub fn list(database: Data<Database>) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::list::list(&database)
-        .map_err(ErrorInternalServerError)
-        .and_then(|users| {
-            HttpResponse::Ok().json(json!({
-                "value": users,
-            }))
-        })
+use crate::model::CurrentAuth;
+
+pub fn list(
+    auth: CurrentAuth,
+    database: Data<Database>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::list::list(&database)
+                .map_err(ErrorInternalServerError)
+                .and_then(|users| {
+                    HttpResponse::Ok().json(json!({
+                        "value": users,
+                    }))
+                }),
+        ),
+    }
 }

--- a/crates/brace-web-auth/src/lib/route/api/mod.rs
+++ b/crates/brace-web-auth/src/lib/route/api/mod.rs
@@ -1,8 +1,9 @@
 use actix_web::error::PayloadError;
 use actix_web::web::{self, Bytes};
-use actix_web::Scope;
+use actix_web::{Resource, Scope};
 use futures::Stream;
 
+pub mod auth;
 pub mod create;
 pub mod delete;
 pub mod list;
@@ -24,4 +25,8 @@ pub fn routes() -> Scope<PayloadStream> {
                 .route(web::put().to_async(update::update))
                 .route(web::delete().to_async(delete::delete)),
         )
+}
+
+pub fn auth_route() -> Resource<PayloadStream> {
+    web::resource("/api/auth").route(web::post().to_async(auth::post))
 }

--- a/crates/brace-web-auth/src/lib/route/api/retrieve.rs
+++ b/crates/brace-web-auth/src/lib/route/api/retrieve.rs
@@ -2,22 +2,35 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::{Data, Path};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use futures::future::{ok, Either, Future};
 use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
+use crate::model::CurrentAuth;
+
 pub fn retrieve(
+    auth: CurrentAuth,
     database: Data<Database>,
     path: Path<Info>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::retrieve::retrieve(&database, path.user)
-        .map_err(ErrorInternalServerError)
-        .and_then(|user| {
-            HttpResponse::Ok().json(json!({
-                "value": user,
-            }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::retrieve::retrieve(&database, path.user)
+                .map_err(ErrorInternalServerError)
+                .and_then(|user| {
+                    HttpResponse::Ok().json(json!({
+                        "value": user,
+                    }))
+                }),
+        ),
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/brace-web-auth/src/lib/route/api/update.rs
+++ b/crates/brace-web-auth/src/lib/route/api/update.rs
@@ -2,20 +2,31 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use futures::future::{ok, Either, Future};
 use serde_json::json;
 
-use crate::model::User;
+use crate::model::{CurrentAuth, User};
 
 pub fn update(
+    auth: CurrentAuth,
     database: Data<Database>,
     user: Json<User>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::update::update(&database, user.into_inner())
-        .map_err(ErrorInternalServerError)
-        .and_then(|user| {
-            HttpResponse::Ok().json(json!({
-                "value": user,
-            }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::update::update(&database, user.into_inner())
+                .map_err(ErrorInternalServerError)
+                .and_then(|user| {
+                    HttpResponse::Ok().json(json!({
+                        "value": user,
+                    }))
+                }),
+        ),
+    }
 }

--- a/crates/brace-web-auth/src/lib/util.rs
+++ b/crates/brace-web-auth/src/lib/util.rs
@@ -1,10 +1,13 @@
 use std::iter::repeat;
 use std::string::FromUtf8Error;
 
-use argon2rs::verifier::DecodeError;
-use argon2rs::verifier::Encoded;
+use argon2rs::verifier::{DecodeError, Encoded};
+use failure::Error;
+use jsonwebtoken::{decode, encode, Header, Validation};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+
+use crate::model::{Claims, SlimUser};
 
 pub fn salt() -> String {
     repeat(())
@@ -22,4 +25,21 @@ pub fn verify(password: &str, hash: &str) -> Result<bool, DecodeError> {
         Ok(enc) => Ok(enc.verify(password.as_bytes())),
         Err(err) => Err(err),
     }
+}
+
+pub fn create_token(data: SlimUser) -> Result<String, Error> {
+    let claims = Claims::with_email(data.email.as_str());
+    let res = encode(&Header::default(), &claims, get_secret().as_ref())?;
+
+    Ok(res)
+}
+
+pub fn decode_token(token: &str) -> Result<SlimUser, Error> {
+    let res = decode::<Claims>(token, get_secret().as_ref(), &Validation::default())?;
+
+    Ok(res.claims.into())
+}
+
+fn get_secret() -> String {
+    "secret".to_string()
 }

--- a/crates/brace-web-auth/tests/route.rs
+++ b/crates/brace-web-auth/tests/route.rs
@@ -5,11 +5,14 @@ use actix_web::http::header::{self, HeaderValue};
 use actix_web::http::{Method, StatusCode};
 use actix_web::App;
 use brace_db::{Database, DatabaseConfig};
+use brace_web_auth::action::create::create;
 use brace_web_auth::action::install::install;
 use brace_web_auth::action::uninstall::uninstall;
 use brace_web_auth::model::User;
-use brace_web_auth::route::api::routes;
+use brace_web_auth::route::api::{auth_route, routes};
 use chrono::Utc;
+use futures::future::Future;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 #[test]
@@ -32,6 +35,7 @@ fn test_user_route_lifecycle() {
         HttpService::new(
             App::new()
                 .data(Database::from_config(DatabaseConfig::default()).unwrap())
+                .service(auth_route())
                 .service(routes()),
         )
     });
@@ -39,10 +43,94 @@ fn test_user_route_lifecycle() {
     let req = srv.request(Method::GET, srv.url("/api/users/")).send();
     let res = srv.block_on(req).unwrap();
 
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let header = res
+        .headers()
+        .get("WWW-Authenticate")
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    assert_eq!(header, r#"Bearer realm="localhost", charset="UTF-8""#);
+
+    let req = srv
+        .request(Method::GET, srv.url("/api/users/"))
+        .header("Authorization", "Bearer invalidtoken")
+        .send();
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv
+        .request(Method::POST, srv.url("/api/users/"))
+        .send_json(&user);
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv.request(Method::GET, srv.url(&path)).send();
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv.request(Method::PUT, srv.url(&path)).send_json(&user);
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv.request(Method::DELETE, srv.url(&path)).send();
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let admin = User {
+        id: Uuid::new_v4(),
+        email: "admin@domain.test".to_string(),
+        password: "password".to_string(),
+        created: Utc::now(),
+        updated: Utc::now(),
+    };
+
+    system.block_on(create(&database, admin)).unwrap();
+
+    let auth = json!({
+        "email": "admin@domain.test",
+        "password": "password",
+    });
+
+    let req = srv
+        .request(Method::POST, srv.url("/api/auth"))
+        .send_json(&auth);
+    let mut res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let json = res.json::<Value>().wait().unwrap();
+    let token = json.get("token").unwrap();
+    let header = format!("Bearer {}", token.as_str().unwrap());
+
+    let uuid = Uuid::new_v4();
+    let path = format!("/api/users/{}", uuid);
+    let user = User {
+        id: uuid,
+        email: "user1@domain.test".to_string(),
+        password: "password1".to_string(),
+        created: Utc::now(),
+        updated: Utc::now(),
+    };
+
+    let req = srv
+        .request(Method::GET, srv.url("/api/users/"))
+        .header("Authorization", header.clone())
+        .send();
+    let res = srv.block_on(req).unwrap();
+
     assert_eq!(res.status(), StatusCode::OK);
 
     let req = srv
         .request(Method::POST, srv.url("/api/users/"))
+        .header("Authorization", header.clone())
         .send_json(&user);
     let res = srv.block_on(req).unwrap();
 
@@ -53,21 +141,24 @@ fn test_user_route_lifecycle() {
     );
 
     let req = srv
-        .request(Method::GET, srv.url(&format!("/api/users/{}", uuid)))
+        .request(Method::GET, srv.url(&path))
+        .header("Authorization", header.clone())
         .send();
     let res = srv.block_on(req).unwrap();
 
     assert_eq!(res.status(), StatusCode::OK);
 
     let req = srv
-        .request(Method::PUT, srv.url(&format!("/api/users/{}", uuid)))
+        .request(Method::PUT, srv.url(&path))
+        .header("Authorization", header.clone())
         .send_json(&user);
     let res = srv.block_on(req).unwrap();
 
     assert_eq!(res.status(), StatusCode::OK);
 
     let req = srv
-        .request(Method::DELETE, srv.url(&format!("/api/users/{}", uuid)))
+        .request(Method::DELETE, srv.url(&path))
+        .header("Authorization", header.clone())
         .send();
     let res = srv.block_on(req).unwrap();
 

--- a/crates/brace-web-page/src/lib/route/api/create.rs
+++ b/crates/brace-web-page/src/lib/route/api/create.rs
@@ -3,22 +3,34 @@ use actix_web::http::header;
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use brace_web_auth::model::CurrentAuth;
+use futures::future::{ok, Either, Future};
 use serde_json::json;
 
 use crate::model::Page;
 
 pub fn create(
+    auth: CurrentAuth,
     database: Data<Database>,
     page: Json<Page>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::create::create(&database, page.into_inner())
-        .map_err(ErrorInternalServerError)
-        .and_then(|page| {
-            HttpResponse::Created()
-                .header(header::LOCATION, format!("/api/pages/{}", page.id))
-                .json(json!({
-                    "value": page,
-                }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::create::create(&database, page.into_inner())
+                .map_err(ErrorInternalServerError)
+                .and_then(|page| {
+                    HttpResponse::Created()
+                        .header(header::LOCATION, format!("/api/pages/{}", page.id))
+                        .json(json!({
+                            "value": page,
+                        }))
+                }),
+        ),
+    }
 }

--- a/crates/brace-web-page/src/lib/route/api/delete.rs
+++ b/crates/brace-web-page/src/lib/route/api/delete.rs
@@ -2,22 +2,34 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::{Data, Path};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use brace_web_auth::model::CurrentAuth;
+use futures::future::{ok, Either, Future};
 use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
 pub fn delete(
+    auth: CurrentAuth,
     database: Data<Database>,
     path: Path<Info>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::delete::delete(&database, path.page)
-        .map_err(ErrorInternalServerError)
-        .and_then(|page| {
-            HttpResponse::Ok().json(json!({
-                "value": page,
-            }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::delete::delete(&database, path.page)
+                .map_err(ErrorInternalServerError)
+                .and_then(|page| {
+                    HttpResponse::Ok().json(json!({
+                        "value": page,
+                    }))
+                }),
+        ),
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/brace-web-page/src/lib/route/api/list.rs
+++ b/crates/brace-web-page/src/lib/route/api/list.rs
@@ -2,15 +2,29 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::Data;
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use brace_web_auth::model::CurrentAuth;
+use futures::future::{ok, Either, Future};
 use serde_json::json;
 
-pub fn list(database: Data<Database>) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::list::list(&database)
-        .map_err(ErrorInternalServerError)
-        .and_then(|pages| {
-            HttpResponse::Ok().json(json!({
-                "value": pages,
-            }))
-        })
+pub fn list(
+    auth: CurrentAuth,
+    database: Data<Database>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::list::list(&database)
+                .map_err(ErrorInternalServerError)
+                .and_then(|pages| {
+                    HttpResponse::Ok().json(json!({
+                        "value": pages,
+                    }))
+                }),
+        ),
+    }
 }

--- a/crates/brace-web-page/src/lib/route/api/retrieve.rs
+++ b/crates/brace-web-page/src/lib/route/api/retrieve.rs
@@ -2,22 +2,34 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::{Data, Path};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use brace_web_auth::model::CurrentAuth;
+use futures::future::{ok, Either, Future};
 use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
 pub fn retrieve(
+    auth: CurrentAuth,
     database: Data<Database>,
     path: Path<Info>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::retrieve::retrieve(&database, path.page)
-        .map_err(ErrorInternalServerError)
-        .and_then(|page| {
-            HttpResponse::Ok().json(json!({
-                "value": page,
-            }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::retrieve::retrieve(&database, path.page)
+                .map_err(ErrorInternalServerError)
+                .and_then(|page| {
+                    HttpResponse::Ok().json(json!({
+                        "value": page,
+                    }))
+                }),
+        ),
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/brace-web-page/src/lib/route/api/update.rs
+++ b/crates/brace-web-page/src/lib/route/api/update.rs
@@ -2,20 +2,32 @@ use actix_web::error::{Error, ErrorInternalServerError};
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
 use brace_db::Database;
-use futures::future::Future;
+use brace_web_auth::model::CurrentAuth;
+use futures::future::{ok, Either, Future};
 use serde_json::json;
 
 use crate::model::Page;
 
 pub fn update(
+    auth: CurrentAuth,
     database: Data<Database>,
     page: Json<Page>,
 ) -> impl Future<Item = HttpResponse, Error = Error> {
-    crate::action::update::update(&database, page.into_inner())
-        .map_err(ErrorInternalServerError)
-        .and_then(|page| {
-            HttpResponse::Ok().json(json!({
-                "value": page,
-            }))
-        })
+    match auth {
+        CurrentAuth::Unauthenticated => Either::A(ok(HttpResponse::Unauthorized()
+            .header(
+                "WWW-Authenticate",
+                r#"Bearer realm="localhost", charset="UTF-8""#,
+            )
+            .finish())),
+        CurrentAuth::Authenticated(_) => Either::B(
+            crate::action::update::update(&database, page.into_inner())
+                .map_err(ErrorInternalServerError)
+                .and_then(|page| {
+                    HttpResponse::Ok().json(json!({
+                        "value": page,
+                    }))
+                }),
+        ),
+    }
 }

--- a/crates/brace-web-page/tests/route.rs
+++ b/crates/brace-web-page/tests/route.rs
@@ -5,11 +5,18 @@ use actix_web::http::header::{self, HeaderValue};
 use actix_web::http::{Method, StatusCode};
 use actix_web::App;
 use brace_db::{Database, DatabaseConfig};
+use brace_web_auth::action::create::create;
+use brace_web_auth::action::install::install as install_users;
+use brace_web_auth::action::uninstall::uninstall as uninstall_users;
+use brace_web_auth::model::User;
+use brace_web_auth::route::api::auth_route;
 use brace_web_page::action::install::install;
 use brace_web_page::action::uninstall::uninstall;
 use brace_web_page::model::Page;
 use brace_web_page::route::api::routes;
 use chrono::Utc;
+use futures::future::Future;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 #[test]
@@ -29,11 +36,13 @@ fn test_page_route_lifecycle() {
     };
 
     system.block_on(install(&database)).unwrap();
+    system.block_on(install_users(&database)).unwrap();
 
     let mut srv = TestServer::new(|| {
         HttpService::new(
             App::new()
                 .data(Database::from_config(DatabaseConfig::default()).unwrap())
+                .service(auth_route())
                 .service(routes()),
         )
     });
@@ -41,10 +50,84 @@ fn test_page_route_lifecycle() {
     let req = srv.request(Method::GET, srv.url("/api/pages/")).send();
     let res = srv.block_on(req).unwrap();
 
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let header = res
+        .headers()
+        .get("WWW-Authenticate")
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    assert_eq!(header, r#"Bearer realm="localhost", charset="UTF-8""#);
+
+    let req = srv
+        .request(Method::GET, srv.url("/api/pages/"))
+        .header("Authorization", "Bearer invalidtoken")
+        .send();
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv
+        .request(Method::POST, srv.url("/api/pages/"))
+        .send_json(&page);
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv.request(Method::GET, srv.url(&path)).send();
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv.request(Method::PUT, srv.url(&path)).send_json(&page);
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let req = srv.request(Method::DELETE, srv.url(&path)).send();
+    let res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+    let admin = User {
+        id: Uuid::new_v4(),
+        email: "admin@domain.test".to_string(),
+        password: "password".to_string(),
+        created: Utc::now(),
+        updated: Utc::now(),
+    };
+
+    system.block_on(create(&database, admin)).unwrap();
+
+    let auth = json!({
+        "email": "admin@domain.test",
+        "password": "password",
+    });
+
+    let req = srv
+        .request(Method::POST, srv.url("/api/auth"))
+        .send_json(&auth);
+    let mut res = srv.block_on(req).unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let json = res.json::<Value>().wait().unwrap();
+    let token = json.get("token").unwrap();
+    let header = format!("Bearer {}", token.as_str().unwrap());
+
+    let req = srv
+        .request(Method::GET, srv.url("/api/pages/"))
+        .header("Authorization", header.clone())
+        .send();
+    let res = srv.block_on(req).unwrap();
+
     assert_eq!(res.status(), StatusCode::OK);
 
     let req = srv
         .request(Method::POST, srv.url("/api/pages/"))
+        .header("Authorization", header.clone())
         .send_json(&page);
     let res = srv.block_on(req).unwrap();
 
@@ -56,6 +139,7 @@ fn test_page_route_lifecycle() {
 
     let req = srv
         .request(Method::GET, srv.url(&format!("/api/pages/{}", uuid)))
+        .header("Authorization", header.clone())
         .send();
     let res = srv.block_on(req).unwrap();
 
@@ -63,6 +147,7 @@ fn test_page_route_lifecycle() {
 
     let req = srv
         .request(Method::PUT, srv.url(&format!("/api/pages/{}", uuid)))
+        .header("Authorization", header.clone())
         .send_json(&page);
     let res = srv.block_on(req).unwrap();
 
@@ -70,10 +155,12 @@ fn test_page_route_lifecycle() {
 
     let req = srv
         .request(Method::DELETE, srv.url(&format!("/api/pages/{}", uuid)))
+        .header("Authorization", header.clone())
         .send();
     let res = srv.block_on(req).unwrap();
 
     assert_eq!(res.status(), StatusCode::OK);
 
     system.block_on(uninstall(&database)).unwrap();
+    system.block_on(uninstall_users(&database)).unwrap();
 }

--- a/crates/brace/src/lib/lib.rs
+++ b/crates/brace/src/lib/lib.rs
@@ -67,6 +67,7 @@ pub fn run(config: AppConfig, path: &Path) -> Result<(), Error> {
             ))
             .service(resource("/").route(get().to_async(route::index::get)))
             .service(resource("/themes").route(get().to_async(route::themes::get)))
+            .service(brace_web_auth::route::api::auth_route())
             .service(brace_web_auth::route::web::login_route())
             .service(brace_web_auth::route::web::logout_route())
             .service(brace_web_auth::route::api::routes())


### PR DESCRIPTION
This enables authentication for secure REST endpoints via the use of JSON Web Tokens. It is currently reliant on an unreleased version of the _jsonwebtoken_ crate due to an incompatibility with the latest version of _actix-web_ because of conflicting versions of the _ring_ crate.