### PR TITLE
Update continuous integration clippy action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         args: --all -- --check
 
     - name: Clippy
-      uses: brace-rs/clippy-check@b75a09651cc90c3921c41888815fe6a7a0b0adae
+      uses: actions-rs/clippy-check@v1
       with:
         args: --all -- -D warnings
         name: Lint / Results


### PR DESCRIPTION
This updates the continuous integration workflow to use the `actions-rs/clippy-check` action now that the fix for unnamed workflows is merged.