### PR TITLE
Add web server feature

### DIFF
--- a/crates/brace/Cargo.toml
+++ b/crates/brace/Cargo.toml
@@ -14,12 +14,20 @@ path = "src/lib/brace.rs"
 [features]
 default = []
 cli = ["clap"]
+web = ["actix-web"]
 
 [dependencies]
+# core
+actix-rt = "1.0"
+anyhow = "1.0"
+# cli
 clap = { version = "3.0.0-beta.1", git = "https://github.com/clap-rs/clap", rev = "81457178fa7e055775867ca659b37798b5ae9584", optional = true }
+# web
+actix-web = { version = "2.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "1.0"
+awc = "1.0"
 predicates = "1.0"
 
 [[bin]]

--- a/crates/brace/src/bin/brace.rs
+++ b/crates/brace/src/bin/brace.rs
@@ -5,6 +5,7 @@ use clap::{crate_version, App, AppSettings};
 mod web;
 
 #[actix_rt::main]
+#[allow(unused_mut, unused_variables)]
 async fn main() -> anyhow::Result<()> {
     let mut app = App::new("brace")
         .about("The brace application framework")

--- a/crates/brace/src/bin/brace.rs
+++ b/crates/brace/src/bin/brace.rs
@@ -1,8 +1,30 @@
-use clap::{crate_version, App};
+use std::process::exit;
 
-fn main() {
-    App::new("brace")
+use clap::{crate_version, App, AppSettings};
+
+mod web;
+
+#[actix_rt::main]
+async fn main() -> anyhow::Result<()> {
+    let mut app = App::new("brace")
         .about("The brace application framework")
         .version(crate_version!())
-        .get_matches();
+        .setting(AppSettings::SubcommandRequired);
+
+    #[cfg(feature = "web")]
+    {
+        app = app.subcommand(self::web::command());
+    }
+
+    let matches = app.get_matches();
+    let subcommand = matches.subcommand();
+
+    #[cfg(feature = "web")]
+    {
+        if let ("web", Some(args)) = subcommand {
+            return self::web::matched(args).await;
+        }
+    }
+
+    exit(1);
 }

--- a/crates/brace/src/bin/web/mod.rs
+++ b/crates/brace/src/bin/web/mod.rs
@@ -1,0 +1,24 @@
+#![cfg(feature = "web")]
+
+use std::process::exit;
+
+use clap::{App, AppSettings, ArgMatches};
+
+pub mod start;
+
+pub fn command<'a>() -> App<'a> {
+    App::new("web")
+        .about("The brace web server")
+        .subcommand(self::start::command())
+        .setting(AppSettings::SubcommandRequired)
+}
+
+pub async fn matched(matches: &ArgMatches) -> anyhow::Result<()> {
+    let subcommand = matches.subcommand();
+
+    if let ("start", Some(args)) = subcommand {
+        return self::start::matched(args).await;
+    }
+
+    exit(1);
+}

--- a/crates/brace/src/bin/web/start.rs
+++ b/crates/brace/src/bin/web/start.rs
@@ -1,0 +1,31 @@
+use std::net::Ipv4Addr;
+
+use clap::{App, Arg, ArgMatches};
+
+pub fn command<'a>() -> App<'a> {
+    App::new("start")
+        .about("Starts the brace web server")
+        .arg(
+            Arg::new("host")
+                .short('h')
+                .long("host")
+                .value_name("string")
+                .about("Sets the host")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new("port")
+                .short('p')
+                .long("port")
+                .value_name("integer")
+                .about("Sets the port")
+                .takes_value(true),
+        )
+}
+
+pub async fn matched(args: &ArgMatches) -> anyhow::Result<()> {
+    let host: Ipv4Addr = args.value_of("host").unwrap_or("127.0.0.1").parse()?;
+    let port: u16 = args.value_of("port").unwrap_or("8080").parse()?;
+
+    brace::web::server::start(host, port).await
+}

--- a/crates/brace/src/lib/brace.rs
+++ b/crates/brace/src/lib/brace.rs
@@ -1,1 +1,1 @@
-
+pub mod web;

--- a/crates/brace/src/lib/web/mod.rs
+++ b/crates/brace/src/lib/web/mod.rs
@@ -1,0 +1,4 @@
+#![cfg(feature = "web")]
+
+pub mod routes;
+pub mod server;

--- a/crates/brace/src/lib/web/routes/index.rs
+++ b/crates/brace/src/lib/web/routes/index.rs
@@ -1,0 +1,5 @@
+use actix_web::Responder;
+
+pub async fn get() -> impl Responder {
+    "brace"
+}

--- a/crates/brace/src/lib/web/routes/mod.rs
+++ b/crates/brace/src/lib/web/routes/mod.rs
@@ -1,0 +1,1 @@
+pub mod index;

--- a/crates/brace/src/lib/web/server/mod.rs
+++ b/crates/brace/src/lib/web/server/mod.rs
@@ -1,0 +1,12 @@
+use std::net::Ipv4Addr;
+
+use actix_web::{web, App, HttpServer};
+
+pub async fn start(host: Ipv4Addr, port: u16) -> anyhow::Result<()> {
+    HttpServer::new(|| App::new().route("/", web::get().to(crate::web::routes::index::get)))
+        .bind((host, port))?
+        .run()
+        .await?;
+
+    Ok(())
+}

--- a/crates/brace/tests/web.rs
+++ b/crates/brace/tests/web.rs
@@ -1,0 +1,36 @@
+#![cfg(all(feature = "cli", feature = "web"))]
+
+use std::error::Error;
+use std::process::Command;
+use std::str::from_utf8;
+use std::thread::sleep;
+use std::time::Duration;
+
+use assert_cmd::prelude::*;
+use awc::Client;
+use predicates::prelude::*;
+
+#[actix_rt::test]
+async fn test_web_cli() -> Result<(), Box<dyn Error>> {
+    let mut cmd = Command::cargo_bin("brace")?;
+
+    cmd.args(&["web", "start", "--host", "127.0.0.1", "--port", "65080"]);
+
+    let mut process = cmd.spawn()?;
+
+    sleep(Duration::from_millis(1000));
+
+    let client = Client::default();
+    let mut res = client.get("http://127.0.0.1:65080").send().await.unwrap();
+
+    assert_eq!(res.status(), 200);
+
+    let body = res.body().await.unwrap();
+    let text = from_utf8(&body)?;
+
+    assert!(predicate::str::contains("brace").eval(text));
+
+    process.kill()?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds an optional `web` feature using `actix-web` to serve a single static index page. This will act as the basis for other features which provide a web interface. This also introduces the `anyhow` crate in order to handle errors in a generic way.